### PR TITLE
Rel v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# peridiod releases
+
+## v1.1.0
+
+* Enhancements
+  * Updated configurator with key_pair_config to allow using pkcs11 or file
+
+Example node settings for different key pair sources:
+
+File:
+
+```elixir
+"key_pair_source": "file",
+"key_pair_config": {
+  "private_key_path": "/etc/peridiod/device-key.pem",
+  "certificate_path": "/etc/peridiod/device-cert.pem"
+}
+```
+
+PKCS11:
+
+```elixir
+"key_pair_source": "pkcs11",
+"key_pair_config": {
+  "key_id": "pkcs11:token=MCHP;object=device;type=private",
+  "cert_id": "pkcs11:token=MCHP;object=device;type=cert"
+}
+```
+
+## v1.0.0
+
+Initial release

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,4 @@ compile:
 	mix compile
 
 release: compile
-	mix release
+	mix release --overwrite

--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -14,9 +14,8 @@ defmodule Peridiod.Config do
       },
       "remote_shell" => cremini_remote_shell,
       "node" => %{
-        "key_pair_source" => _key_pair_source,
-        "certificate_path" => node_certificate_path,
-        "private_key_path" => node_private_key_path
+        "key_pair_source" => key_pair_source,
+        "key_pair_config" => key_pair_config
       },
       "version" => 1
     } = config
@@ -33,8 +32,8 @@ defmodule Peridiod.Config do
       },
       remote_shell: cremini_remote_shell,
       node: %{
-        certificate_path: node_certificate_path,
-        private_key_path: node_private_key_path
+        key_pair_source: key_pair_source,
+        key_pair_config: key_pair_config
       }
     }
   end

--- a/lib/peridiod/configurator.ex
+++ b/lib/peridiod/configurator.ex
@@ -1,5 +1,8 @@
 defmodule Peridiod.Configurator do
+  alias __MODULE__
   alias Peridiod.Config
+
+  require Logger
 
   @behaviour NervesHubLink.Configurator
 
@@ -14,7 +17,7 @@ defmodule Peridiod.Configurator do
         true -> :verify_peer
         false -> :verify_none
       end
-
+    config =
     %{
       base_nerves_config
       | device_api_host: peridio_config.device_api.url,
@@ -27,9 +30,16 @@ defmodule Peridiod.Configurator do
           server_name_indication: to_charlist(peridio_config.device_api.url),
           verify: verify,
           cacertfile: peridio_config.device_api.certificate_path,
-          certfile: peridio_config.node.certificate_path,
-          keyfile: peridio_config.node.private_key_path
         ]
     }
+
+    case peridio_config.node.key_pair_source do
+      "file" ->
+        Configurator.File.config(peridio_config.node.key_pair_config, config)
+      "pkcs11" ->
+        Configurator.PKCS11.config(peridio_config.node.key_pair_config, config)
+      type ->
+        Logger.error("Unknown key pair type: #{type}")
+    end
   end
 end

--- a/lib/peridiod/configurator/file.ex
+++ b/lib/peridiod/configurator/file.ex
@@ -1,0 +1,16 @@
+defmodule Peridiod.Configurator.File do
+  require Logger
+  def config(%{"certificate_path" => cert_path, "private_key_path" => key_path}, nerves_config) do
+    ssl_opts =
+      nerves_config.ssl
+      |> Keyword.put(:certfile, cert_path)
+      |> Keyword.put(:keyfile, key_path)
+
+    %{nerves_config | ssl: ssl_opts}
+  end
+
+  def config(_, nerves_config) do
+    Logger.error("key_pair_source file requires certificate_path and private_key_path to be passed as key_pair_options")
+    nerves_config
+  end
+end

--- a/lib/peridiod/configurator/pkcs11.ex
+++ b/lib/peridiod/configurator/pkcs11.ex
@@ -1,0 +1,39 @@
+defmodule Peridiod.Configurator.PKCS11 do
+  require Logger
+  def config(%{"key_id" => key_id, "cert_id" => cert_id} = key_pair_config, nerves_config) do
+    pkcs11_path = key_pair_config["pkcs11_path"] || pkcs11_path()
+
+    {:ok, engine} = :crypto.ensure_engine_loaded("pkcs11", pkcs11_path)
+    key = %{
+        algorithm: :ecdsa,
+        engine: engine,
+        key_id: key_id,
+    }
+
+    cert =
+      case System.cmd("p11tool", ["--export-stapled", cert_id]) do
+        {cert_pem, 0} ->
+          cert_pem |> X509.Certificate.from_pem!() |> X509.Certificate.to_der()
+        {error, _} ->
+          Logger.error("An error occurred while reading the certificate from pkcs11:\n#{error}")
+          ""
+      end
+
+    ssl_opts =
+      nerves_config.ssl
+      |> Keyword.put(:cert, cert)
+      |> Keyword.put(:key, key)
+
+    %{nerves_config | ssl: ssl_opts}
+  end
+
+
+
+  defp pkcs11_path() do
+    [
+      "/usr/lib/engines-1.1/libpkcs11.so",
+      "/usr/lib/engines/libpkcs11.so"
+    ]
+    |> Enum.find(&File.exists?/1)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,8 @@ defmodule Peridiod.MixProject do
     [
       {:jason, "~> 1.0"},
       {:nerves_hub_cli, "~> 0.11.1", runtime: false},
-      {:nerves_hub_link, "~> 1.2"}
+      {:nerves_hub_link, "~> 1.2"},
+      {:x509, "~> 0.8"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Peridiod.MixProject do
   def project do
     [
       app: :peridiod,
-      version: "1.0.0",
+      version: "1.1.0",
       elixir: "~> 1.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
* Enhancements
  * Updated configurator with key_pair_config to allow using pkcs11 or file

Example node settings for different key pair sources:

File:

```elixir
"key_pair_source": "file",
"key_pair_config": {
  "private_key_path": "/etc/peridiod/device-key.pem",
  "certificate_path": "/etc/peridiod/device-cert.pem"
}
```

PKCS11:

```elixir
"key_pair_source": "pkcs11",
"key_pair_config": {
  "key_id": "pkcs11:token=MCHP;object=device;type=private",
  "cert_id": "pkcs11:token=MCHP;object=device;type=cert"
}
```