### PR TITLE
v2.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # peridiod releases
 
+## v2.1.0
+
+* Updates
+  * `PERIDIOD_INCLUDE_ERTS_DIR` is now `MIX_TARGET_INCLUDE_ERTS`
+    Change environment variable to be friendly to yocto buikds.
+    If you are building peridiod outside yocto, you will need to 
+    update your build scripts to use the new variable.
+
 ## v2.0.1
 
 * Bug Fixes

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Peridiod.MixProject do
   def project do
     [
       app: :peridiod,
-      version: "2.0.1",
+      version: "2.1.0",
       elixir: "~> 1.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
* Updates
  * `PERIDIOD_INCLUDE_ERTS_DIR` is now `MIX_TARGET_INCLUDE_ERTS`
    Change environment variable to be friendly to yocto buikds.
    If you are building peridiod outside yocto, you will need to 
    update your build scripts to use the new variable.