### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # peridiod releases
 
+## v2.2.0
+
+* Updated default retry parameters to accommodate slow connections like
+  NB-IoT 1
+* Enhanced debug logging
+
 ## v2.1.0
 
 * Updates

--- a/lib/peridiod/client/default.ex
+++ b/lib/peridiod/client/default.ex
@@ -10,19 +10,19 @@ defmodule Peridiod.Client.Default do
 
   @impl Peridiod.Client
   def handle_fwup_message({:progress, percent}) do
-    Logger.debug("[Peridio] Update Progress: #{percent}%")
+    Logger.debug("[Peridiod] Update Progress: #{percent}%")
   end
 
   def handle_fwup_message({:error, _, message}) do
-    Logger.error("[Peridio] Update Error: #{message}")
+    Logger.error("[Peridiod] Update Error: #{message}")
   end
 
   def handle_fwup_message({:warning, _, message}) do
-    Logger.warn("[Peridio] Update Warning: #{message}")
+    Logger.warn("[Peridiod] Update Warning: #{message}")
   end
 
   def handle_fwup_message({:ok, status, message}) do
-    Logger.info("[Peridio] Update Finished: #{status} #{message}")
+    Logger.info("[Peridiod] Update Finished: #{status} #{message}")
   end
 
   def handle_fwup_message(fwup_message) do
@@ -31,13 +31,13 @@ defmodule Peridiod.Client.Default do
 
   @impl Peridiod.Client
   def handle_error(error) do
-    Logger.warn("[Peridio] error: #{inspect(error)}")
+    Logger.warn("[Peridiod] error: #{inspect(error)}")
   end
 
   @impl Peridiod.Client
   def reboot() do
     # this function must reboot the system
-    Logger.warn("[Peridio] Rebooting System")
+    Logger.warn("[Peridiod] Rebooting System")
     System.cmd("reboot", [], stderr_to_stdout: true)
   end
 end

--- a/lib/peridiod/downloader/retry_config.ex
+++ b/lib/peridiod/downloader/retry_config.ex
@@ -6,7 +6,7 @@ defmodule Peridiod.Downloader.RetryConfig do
 
   defstruct [
     # stop trying after this many disconnects
-    max_disconnects: 10,
+    max_disconnects: 50,
 
     # attempt a retry after this time
     # if no data comes in after this amount of time, disconnect and retry
@@ -23,8 +23,9 @@ defmodule Peridiod.Downloader.RetryConfig do
 
     # worst case average download speed in bits/second
     # This is used to calculate a "sensible" timeout that is shorter than `max_timeout`.
-    # LTE Cat M1 modems sometimes top out at 32 kbps (30 kbps for some slack)
-    worst_case_download_speed: 30_000
+    # LTE Cat1 NB-IoT modems sometimes top out at 10 kbps but we've seen as slow
+    # as 1 kbps
+    worst_case_download_speed: 1_000
   ]
 
   @typedoc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Peridiod.MixProject do
   def project do
     [
       app: :peridiod,
-      version: "2.1.0",
+      version: "2.2.0",
       elixir: "~> 1.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## v2.2.0

* Updated default retry parameters to accommodate slow connections like
  NB-IoT 1
* Enhanced debug logging

Tested on Cat M1 / NB-IoT 1&2 