### PR TITLE
filter out non utf8 characters from getty stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # peridiod releases
 
+## v2.4.2
+
+* Bug fixes
+  * Filter out characters that are not UTF8 before serializing the console.
+
 ## v2.4.1
 
 * Enhancements
-  * mix release no longer builds a tar into the release directory
+  * mix release no longer builds a tar into the release directory.
 
 ## v2.4.0
 

--- a/lib/peridiod/socket.ex
+++ b/lib/peridiod/socket.ex
@@ -191,6 +191,7 @@ defmodule Peridiod.Socket do
 
   @impl Slipstream
   def handle_info({:tty_data, data}, socket) do
+    data = remove_unwanted_chars(data)
     _ = push(socket, @console_topic, "up", %{data: data})
     {:noreply, socket}
   end
@@ -224,6 +225,7 @@ defmodule Peridiod.Socket do
   end
 
   def handle_info({:getty, _pid, data}, socket) do
+    data = remove_unwanted_chars(data)
     _ = push(socket, @console_topic, "up", %{data: data})
     {:noreply, socket}
   end
@@ -295,4 +297,14 @@ defmodule Peridiod.Socket do
     socket
     |> assign(getty_pid: nil)
   end
+
+  defp remove_unwanted_chars(input) when is_binary(input) do
+    input
+    |> String.codepoints()
+    |> Enum.filter(&valid_codepoint?/1)
+    |> Enum.join()
+  end
+
+  defp valid_codepoint?(<<_::utf8>>), do: true
+  defp valid_codepoint?(_), do: false
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Peridiod.MixProject do
   def project do
     [
       app: :peridiod,
-      version: "2.4.1",
+      version: "2.4.2",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
The getty stream may contain non utf8 characters which break the serializer for the websocket. Filter them out before the serialize. 