### PR TITLE
v2.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # peridiod releases
 
+## v2.5.0
+
+* Enhancements
+  * Add support for choosing between IEx and getty remote shell
+    * `remote_iex: true | false`: Enable / disable the remote console using IEx shell. Useful for Nerves based applications. Setting this to true will take precedence over `remote_shell`.
+    * `remote_shell: true | false`. Enable / disable the remote console using a terminal Getty. Useful for all other embedded linux based systems. Requires `socat` to be available on the target.
+  * Add support for Remote Access Tunnels. Using this feature will require a Peridio Cloud account with the feature enabled. Contact support@peridio.com for more information.
+  * Added support for configuring `peridiod` as an elixir dependency. This is useful if you are consuming `peridiod` as a dependency in a Nerves based application.
+  * Configuration will default to reasonable default values if they are unspecified.
+  * Added config key `fwup_env: {"KEY": "value", "KEY2": "value2"}`. These key value pairs will be exported into the environment that `fwup` is applied in. This is useful if you need to pass extra arguments passed through the environment.
+  * Added config key `fwup_extra_args: ["--unsafe"]`. Useful if you need to pass extra args to `fwup` such as the `--unsafe` flag.
+
 ## v2.4.2
 
 * Bug fixes

--- a/lib/peridiod/configurator.ex
+++ b/lib/peridiod/configurator.ex
@@ -221,8 +221,10 @@ defmodule Peridiod.Configurator do
 
     %{
       enabled: rat_config_file["enabled"] || rat_config[:enabled] || false,
-      port_range: rat_config_file["port_range"] || rat_config[:port_range] |> encode_port_range(),
-      ipv4_cidrs: rat_config_file["ipv4_cidrs"] || rat_config[:ipv4_cidrs] |> encode_ipv4_cidrs(),
+      port_range:
+        (rat_config_file["port_range"] || rat_config[:port_range]) |> encode_port_range(),
+      ipv4_cidrs:
+        (rat_config_file["ipv4_cidrs"] || rat_config[:ipv4_cidrs]) |> encode_ipv4_cidrs(),
       service_ports: rat_config_file["service_ports"] || rat_config[:service_ports] || [],
       persistent_keepalive:
         rat_config_file["persistent_keepalive"] || rat_config[:persistent_keepalive] || 25,

--- a/lib/peridiod/socket.ex
+++ b/lib/peridiod/socket.ex
@@ -190,10 +190,9 @@ defmodule Peridiod.Socket do
   def handle_message(
         @device_topic,
         "tunnel_request",
-        %{"tunnel_prn" => tunnel_prn} = request,
+        %{"tunnel_prn" => tunnel_prn, "device_tunnel_port" => dport} = request,
         socket
       ) do
-    dport = request["device_tunnel_port"] || 22
     service_ports = socket.assigns.remote_access_tunnels.service_ports
 
     if dport in service_ports do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Peridiod.MixProject do
   def project do
     [
       app: :peridiod,
-      version: "2.5.0-dev.1",
+      version: "2.5.0",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
* Enhancements
  * Add support for choosing between IEx and getty remote shell
    * `remote_iex: true | false`: Enable / disable the remote console using IEx shell. Useful for Nerves based applications. Setting this to true will take precedence over `remote_shell`.
    * `remote_shell: true | false`. Enable / disable the remote console using a terminal Getty. Useful for all other embedded linux based systems. Requires `socat` to be available on the target.
  * Add support for Remote Access Tunnels. Using this feature will require a Peridio Cloud account with the feature enabled. Contact support@peridio.com for more information.
  * Added support for configuring `peridiod` as an elixir dependency. This is useful if you are consuming `peridiod` as a dependency in a Nerves based application.
  * Configuration will default to reasonable default values if they are unspecified.
  * Added config key `fwup_env: {"KEY": "value", "KEY2": "value2"}`. These key value pairs will be exported into the environment that `fwup` is applied in. This is useful if you need to pass extra arguments passed through the environment.
  * Added config key `fwup_extra_args: ["--unsafe"]`. Useful if you need to pass extra args to `fwup` such as the `--unsafe` flag.