### PR TITLE
Build and push container images and artifacts on tagged releases

### DIFF
--- a/.github/workflows/build_push_release.yml
+++ b/.github/workflows/build_push_release.yml
@@ -1,0 +1,137 @@
+name: Build and Push Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  create_release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set Env
+      run: |
+        VERSION=$(echo "${GITHUB_REF#refs/*/}" | sed 's/^v//')
+        echo "RELEASE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
+
+    - name: Create GitHub Release
+      id: create_release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if gh release view $RELEASE_TAG &>/dev/null; then
+          echo "Release $RELEASE_TAG exists. skipping"
+        else
+          echo "Release $RELEASE_TAG does not exists. creating..."
+          RELEASE_NOTES=$(sed -e "/^## ${RELEASE_TAG}/,/^## / ! d" CHANGELOG.md | tail -n +2 | head -n -1)
+          gh release create $RELEASE_TAG \
+            --generate-notes \
+            --title $RELEASE_TAG \
+            --notes "$RELEASE_NOTES"
+        fi
+
+  create_release_artifacts:
+    permissions:
+      contents: write
+    runs-on: "${{ matrix.os }}"
+    needs: create_release
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest-4-cores-arm64
+            target: arm64
+          - os: ubuntu-latest
+            target: amd64
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set Env
+      run: |
+        VERSION=$(echo "${GITHUB_REF#refs/*/}" | sed 's/^v//')
+        echo "RELEASE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
+
+    - name: Build release artifacts
+      run: |
+        docker build --output type=local,dest=docker_output/ -f release/Containerfile-build.${{ matrix.target }} .
+
+    - name: Upload Release Asset
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        mv ./docker_output/${{ matrix.target }}/peridiod-${RELEASE_VERSION}.tar.gz ./docker_output/peridiod-${RELEASE_VERSION}-${{ matrix.target }}.tar.gz
+        gh release upload $RELEASE_TAG ./docker_output/peridiod-${RELEASE_VERSION}-${{ matrix.target }}.tar.gz --clobber
+
+    - name: Load docker hub credentials
+      id: op-load-docker-hub-credentials
+      uses: 1password/load-secrets-action@v1
+      with:
+        export-env: false
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        DOCKER_HUB_USERNAME: op://ci-cd/docker-hub-machine/username
+        DOCKER_HUB_PASSWORD: op://ci-cd/docker-hub-machine/password
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ steps.op-load-docker-hub-credentials.outputs.DOCKER_HUB_USERNAME }}
+        password: ${{ steps.op-load-docker-hub-credentials.outputs.DOCKER_HUB_PASSWORD }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./release/Containerfile-release
+        push: true
+        tags: |
+          peridio/peridiod:${{ env.RELEASE_TAG }}-${{ matrix.target }}
+
+  push_container_images:
+    runs-on: ubuntu-latest
+    needs: create_release_artifacts
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set Env
+      run: |
+        echo "RELEASE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+    - name: Load docker hub credentials
+      id: op-load-docker-hub-credentials
+      uses: 1password/load-secrets-action@v1
+      with:
+        export-env: false
+      env:
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        DOCKER_HUB_USERNAME: op://ci-cd/docker-hub-machine/username
+        DOCKER_HUB_PASSWORD: op://ci-cd/docker-hub-machine/password
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ steps.op-load-docker-hub-credentials.outputs.DOCKER_HUB_USERNAME }}
+        password: ${{ steps.op-load-docker-hub-credentials.outputs.DOCKER_HUB_PASSWORD }}
+
+    - name: Create and Push Manifest
+      run: |
+        docker manifest create peridio/peridiod:${{ env.RELEASE_TAG }} \
+          --amend peridio/peridiod:${{ env.RELEASE_TAG }}-arm64 \
+          --amend peridio/peridiod:${{ env.RELEASE_TAG }}-amd64
+        docker manifest create peridio/peridiod:latest \
+          --amend peridio/peridiod:${{ env.RELEASE_TAG }}-arm64 \
+          --amend peridio/peridiod:${{ env.RELEASE_TAG }}-amd64
+        docker manifest push peridio/peridiod:${{ env.RELEASE_TAG }}
+        docker manifest push peridio/peridiod:latest

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.16.2-alpine AS build
+FROM elixir:1.16.3-alpine AS build
 
 ARG MIX_ENV=prod
 ARG UBOOT_ENV_SIZE=0x20000

--- a/release/Containerfile-build.amd64
+++ b/release/Containerfile-build.amd64
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 hexpm/elixir:1.16.2-erlang-26.2.5-ubuntu-noble-20240429 AS build
+FROM --platform=linux/amd64 hexpm/elixir:1.16.3-erlang-26.2.5.1-ubuntu-noble-20240605 AS build
 
 ARG MIX_ENV=prod
 ARG UBOOT_ENV_SIZE=0x20000

--- a/release/Containerfile-build.arm64
+++ b/release/Containerfile-build.arm64
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64/v8 hexpm/elixir:1.16.2-erlang-26.2.5-ubuntu-noble-20240429 AS build
+FROM --platform=linux/arm64/v8 hexpm/elixir:1.16.3-erlang-26.2.5.1-ubuntu-noble-20240605 AS build
 
 ARG MIX_ENV=prod
 ARG UBOOT_ENV_SIZE=0x20000

--- a/release/Containerfile-release
+++ b/release/Containerfile-release
@@ -1,0 +1,74 @@
+FROM elixir:1.16.3-alpine AS build
+
+ARG MIX_ENV=prod
+
+RUN apk add --no-cache \
+    linux-headers \
+    build-base \
+    gcc \
+    automake \
+    u-boot-tools \
+    libsodium-dev \
+    autoconf \
+    libtool \
+    libarchive-dev \
+    confuse-dev \
+    xdelta3 \
+    dosfstools \
+    help2man \
+    curl \
+    mtools \
+    unzip \
+    zip \
+    make \
+    git
+
+RUN mix archive.install github hexpm/hex branch latest --force
+RUN /usr/local/bin/mix local.rebar --force
+
+# Build fwup here to ensure that its built for the arch
+WORKDIR /opt
+RUN git clone https://github.com/fwup-home/fwup --depth 1 --branch v1.10.2
+WORKDIR /opt/fwup
+RUN ./autogen.sh && PKG_CONFIG_PATH=$PKG_CONFIG_PATH ./configure --enable-shared=no && make && make install
+
+RUN mkdir -p /opt/app
+ADD . /opt/app/
+
+WORKDIR /opt/app
+
+RUN mix deps.get --only $MIX_ENV
+RUN mix release --overwrite
+
+FROM alpine:3.20 as app
+
+RUN apk add --no-cache \
+    agetty \
+    confuse \
+    libarchive \
+    libstdc++ \
+    libgcc \
+    socat \
+    iproute2  \
+    iptables \
+    uuidgen \
+    openssl \
+    u-boot-tools \
+    wireguard-tools-wg-quick \
+    openssh-server \
+    coreutils
+
+ENV PERIDIO_CONFIG_FILE=/etc/peridiod/peridio.json
+
+RUN mkdir -p /etc/peridiod
+RUN echo "echo \"Reboot Requested\"" > /usr/bin/reboot && chmod +x /usr/bin/reboot
+RUN ln -s /etc/peridiod/fw_env.config /etc/fw_env.config
+
+COPY --from=build /opt/app/priv/peridio-cert.pem /etc/peridiod/peridio-cert.pem
+COPY --from=build /opt/app/_build/prod/rel/peridiod /opt/peridiod
+COPY --from=build /opt/app/release/peridio.json /etc/peridiod/peridio.json
+COPY --from=build /opt/fwup/src/fwup /usr/bin/fwup
+
+WORKDIR /opt/peridiod
+
+CMD ["/opt/peridiod/bin/peridiod", "start_iex"]

--- a/release/peridio.json
+++ b/release/peridio.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "fwup": {
+    "devpath": "/dev/null"
+  },
+  "remote_shell": true,
+  "remote_access_tunnels": {
+    "enabled": true,
+    "service_ports": [22]
+  },
+  "node": {
+    "key_pair_source": "env",
+    "key_pair_config": {
+      "private_key": "PERIDIO_PRIVATE_KEY",
+      "certificate": "PERIDIO_CERTIFICATE"
+    }
+  }
+}


### PR DESCRIPTION
Performs the following when a tag is pushed
* Create a new Release if one doesn't already exist
* Pull release notes from CHANGELOG.md for the tag listed as `## $TAG` IE `## v2.5.4`
* Build arch specific containers for `arm64` and `amd64` `peridiod` release bundles and upload to the release page
* Build arch specific containers for `arm64` and `amd64` and push to docker hub
* Combine docker arch specific images into `peridio/peridiod:$TAG` and `peridio/peridiod/latest` to make a multiarch image
* Push