### PR TITLE
Add support to install deb / rpm packages

### DIFF
--- a/lib/peridiod/binary/installer.ex
+++ b/lib/peridiod/binary/installer.ex
@@ -278,6 +278,12 @@ defmodule Peridiod.Binary.Installer do
   defp installer_mod(%Binary{custom_metadata: %{"peridiod" => %{"installer" => "file"}}}),
     do: Installer.File
 
+  defp installer_mod(%Binary{custom_metadata: %{"peridiod" => %{"installer" => "deb"}}}),
+    do: Installer.Deb
+
+  defp installer_mod(%Binary{custom_metadata: %{"peridiod" => %{"installer" => "rpm"}}}),
+    do: Installer.Rpm
+
   defp do_install_from_cache(state) do
     cache_file = Binary.cache_file(state.binary_metadata)
     send(self(), {:cache_install, :start})

--- a/lib/peridiod/binary/installer/deb.ex
+++ b/lib/peridiod/binary/installer/deb.ex
@@ -1,0 +1,47 @@
+defmodule Peridiod.Binary.Installer.Deb do
+  use Peridiod.Binary.Installer.Behaviour
+
+  alias Peridiod.Binary
+
+  def install_init(
+        binary_metadata,
+        opts,
+        _source,
+        _config
+      ) do
+    cache_dir = Binary.cache_dir(binary_metadata)
+
+    with :ok <- File.mkdir_p(cache_dir),
+         {:ok, id} <- Binary.id_from_prn(binary_metadata.prn) do
+      cache_file = Path.join([cache_dir, id])
+      {:ok, {cache_file, opts}}
+    else
+      {:error, error} ->
+        {:error, error, nil}
+    end
+  end
+
+  def install_update(_binary_metadata, data, {cache_file, opts}) do
+    File.write(cache_file, data, [:append, :binary])
+    {:ok, {cache_file, opts}}
+  end
+
+  def install_finish(_binary_metadata, :valid_signature, _hash, {cache_file, opts}) do
+    extra_args = opts["extra_args"] || []
+
+    case System.cmd("apt", ["install", "-y", cache_file] ++ extra_args) do
+      {_result, 0} ->
+        File.rm(cache_file)
+        {:stop, :normal, nil}
+
+      {error, _} ->
+        File.rm(cache_file)
+        {:error, error, nil}
+    end
+  end
+
+  def install_finish(_binary_metadata, invalid, _hash, {cache_file, _opts}) do
+    File.rm(cache_file)
+    {:error, invalid, nil}
+  end
+end

--- a/lib/peridiod/binary/installer/rpm.ex
+++ b/lib/peridiod/binary/installer/rpm.ex
@@ -1,0 +1,47 @@
+defmodule Peridiod.Binary.Installer.Rpm do
+  use Peridiod.Binary.Installer.Behaviour
+
+  alias Peridiod.Binary
+
+  def install_init(
+        binary_metadata,
+        opts,
+        _source,
+        _config
+      ) do
+    cache_dir = Binary.cache_dir(binary_metadata)
+
+    with :ok <- File.mkdir_p(cache_dir),
+         {:ok, id} <- Binary.id_from_prn(binary_metadata.prn) do
+      cache_file = Path.join([cache_dir, id])
+      {:ok, {cache_file, opts}}
+    else
+      {:error, error} ->
+        {:error, error, nil}
+    end
+  end
+
+  def install_update(_binary_metadata, data, {cache_file, opts}) do
+    File.write(cache_file, data, [:append, :binary])
+    {:ok, {cache_file, opts}}
+  end
+
+  def install_finish(_binary_metadata, :valid_signature, _hash, {cache_file, opts}) do
+    extra_args = opts["extra_args"] || []
+
+    case System.cmd("dnf", ["install", "-y", cache_file] ++ extra_args) do
+      {_result, 0} ->
+        File.rm(cache_file)
+        {:stop, :normal, nil}
+
+      {error, _} ->
+        File.rm(cache_file)
+        {:error, error, nil}
+    end
+  end
+
+  def install_finish(_binary_metadata, invalid, _hash, {cache_file, _opts}) do
+    File.rm(cache_file)
+    {:error, invalid, nil}
+  end
+end


### PR DESCRIPTION
Allows custom metadata for invoking package manager installers for deb / rpm
* `"installer": "deb"`
* `"installer": "rpm"`