### PR TITLE
Tidy up tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,6 +3,7 @@ import Config
 System.put_env("PERIDIO_CONFIG_FILE", "test/fixtures/peridio.json")
 
 config :logger, level: :error
+config :ex_unit, capture_log: true
 
 config :peridiod_persistence,
   kv_backend:

--- a/lib/peridiod/binary/installer/behaviour.ex
+++ b/lib/peridiod/binary/installer/behaviour.ex
@@ -12,7 +12,7 @@ defmodule Peridiod.Binary.Installer.Behaviour do
       end
 
       def install_update(%Peridiod.Binary{}, {:error, reason}, state) do
-        {:error, reason}
+        {:error, reason, state}
       end
 
       def install_finish(%Peridiod.Binary{}, :invalid_signature, state) do
@@ -23,7 +23,15 @@ defmodule Peridiod.Binary.Installer.Behaviour do
         {:ok, installer_state}
       end
 
-      defoverridable install_init: 3, install_update: 3, install_finish: 3, install_info: 2
+      def install_error(%Peridiod.Binary{}, error, installer_state) do
+        {:error, error, installer_state}
+      end
+
+      defoverridable install_init: 3,
+                     install_update: 3,
+                     install_finish: 3,
+                     install_info: 2,
+                     install_error: 3
     end
   end
 
@@ -35,6 +43,10 @@ defmodule Peridiod.Binary.Installer.Behaviour do
   @callback install_init(Binary.t(), :cache | :download, installer_opts, installer_state()) ::
               {:ok, installer_state()} | {:error, reason :: any(), installer_state()}
   @callback install_update(Binary.t(), data :: binary(), installer_state()) ::
+              {:ok, installer_state()} | {:error, reason :: any(), installer_state()}
+  @callback install_info(msg :: any, installer_state()) ::
+              {:ok, installer_state()} | {:error, reason :: any(), installer_state()}
+  @callback install_error(Binary.t(), reason :: any(), installer_state()) ::
               {:ok, installer_state()} | {:error, reason :: any(), installer_state()}
   @callback install_finish(Binary.t(), :valid_signature | :invalid_signature, installer_state()) ::
               {:stop, reason :: any(), installer_state()}

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -78,13 +78,6 @@ defmodule PeridiodTest.Case do
       end
 
     {:ok, pid} = Release.Server.start_link(config, [])
-
-    on_exit(fn ->
-      if Process.alive?(pid) do
-        Release.Server.stop(pid)
-      end
-    end)
-
     Map.put(context, :release_server_pid, pid)
   end
 end


### PR DESCRIPTION
Tidy up test logs and further prevent random failures. Update the binary installer behaviour to include missing callback specs