### PR TITLE
Pull Bundles apart from Releases

### DIFF
--- a/lib/peridiod/bundle.ex
+++ b/lib/peridiod/bundle.ex
@@ -1,0 +1,135 @@
+defmodule Peridiod.Bundle do
+  alias Peridiod.{Binary, Cache, Bundle}
+
+  import Peridiod.Utils, only: [stamp_utc_now: 0]
+
+  @cache_dir "bundle"
+  @stamp_cached ".stamp_cached"
+  @stamp_installed ".stamp_installed"
+
+  defstruct prn: nil,
+            binaries: nil
+
+  @type t() :: %__MODULE__{
+          prn: String.t(),
+          binaries: [Binary.t()]
+        }
+
+  defimpl Jason.Encoder, for: Bundle do
+    def encode(%Bundle{} = bundle_metadata, opts) do
+      bundle_metadata
+      |> Map.take([:prn])
+      |> Jason.Encode.map(opts)
+    end
+  end
+
+  def metadata_from_cache(cache_pid, bundle_prn) do
+    manifest_file = Path.join([cache_dir(bundle_prn), "manifest"])
+
+    with {:ok, json} <- Cache.read(cache_pid, manifest_file),
+         {:ok, bundle_metadata} <- metadata_from_json(json) do
+      binaries_dir = Path.join(cache_dir(bundle_metadata), "binaries")
+
+      binaries =
+        case Cache.ls(cache_pid, binaries_dir) do
+          {:ok, binary_prns} ->
+            binary_prns
+            |> Enum.reduce([], fn dirname, acc ->
+              case Binary.metadata_from_cache(cache_pid, dirname) do
+                {:ok, binary_metadata} -> [binary_metadata | acc]
+                _error -> acc
+              end
+            end)
+
+          _error ->
+            []
+        end
+
+      {:ok, Map.put(bundle_metadata, :binaries, binaries)}
+    end
+  end
+
+  def metadata_from_json(json) when is_binary(json) do
+    with {:ok, map} <- Jason.decode(json) do
+      {:ok, metadata_from_map(map)}
+    else
+      error -> error
+    end
+  end
+
+  def metadata_from_map(bundle_metadata) do
+    %__MODULE__{
+      prn: bundle_metadata["prn"]
+    }
+  end
+
+  @doc """
+  Recursively parse a release manifest into structs
+  """
+  @spec metadata_from_manifest(map()) :: {:ok, t()}
+  def metadata_from_manifest(%{
+        "manifest" => binaries,
+        "bundle" => bundle_metadata
+      }) do
+    {:ok,
+     %__MODULE__{
+       prn: bundle_metadata["prn"],
+       binaries: Enum.map(binaries, &Binary.metadata_from_manifest/1)
+     }}
+  end
+
+  def metadata_to_cache(
+        cache_pid \\ Cache,
+        %__MODULE__{binaries: binaries} = bundle_metadata
+      ) do
+    bundle_json = Jason.encode!(bundle_metadata)
+    bundle_path = Path.join(["bundle", bundle_metadata.prn])
+    manifest_file = Path.join([bundle_path, "manifest"])
+
+    with :ok <- Cache.write(cache_pid, manifest_file, bundle_json) do
+      Enum.each(binaries, fn binary_metadata ->
+        Binary.metadata_to_cache(cache_pid, binary_metadata)
+        target = Binary.cache_dir(binary_metadata)
+
+        link =
+          Path.join([
+            bundle_path,
+            "binaries",
+            binary_metadata.prn <>
+              ":" <> Base.encode16(binary_metadata.custom_metadata_hash, case: :lower)
+          ])
+
+        Cache.ln_s(cache_pid, target, link)
+      end)
+    end
+  end
+
+  def cache_dir(%__MODULE__{prn: bundle_prn}) do
+    cache_dir(bundle_prn)
+  end
+
+  def cache_dir(bundle_prn) when is_binary(bundle_prn) do
+    Path.join([@cache_dir, bundle_prn])
+  end
+
+  def installed?(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
+    stamp_file = Path.join([cache_dir(release_metadata), @stamp_installed])
+    Cache.exists?(cache_pid, stamp_file)
+  end
+
+  def stamp_cached(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
+    stamp_file = Path.join([cache_dir(release_metadata), @stamp_cached])
+    Cache.write(cache_pid, stamp_file, stamp_utc_now())
+  end
+
+  def stamp_installed(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
+    stamp_file = Path.join([cache_dir(release_metadata), @stamp_installed])
+    Cache.write(cache_pid, stamp_file, stamp_utc_now())
+  end
+
+  def filter_binaries_by_targets(%__MODULE__{binaries: binaries}, []), do: binaries
+
+  def filter_binaries_by_targets(%__MODULE__{binaries: binaries}, targets) do
+    Enum.filter(binaries, &(&1.target in [nil, "" | targets]))
+  end
+end

--- a/lib/peridiod/release.ex
+++ b/lib/peridiod/release.ex
@@ -1,8 +1,10 @@
 defmodule Peridiod.Release do
-  alias Peridiod.{Binary, Cache, Release}
+  alias Peridiod.{Cache, Release, Bundle}
   alias PeridiodPersistence.KV
 
   import Peridiod.Utils, only: [stamp_utc_now: 0]
+
+  require Logger
 
   @cache_dir "release"
   @stamp_cached ".stamp_cached"
@@ -12,16 +14,14 @@ defmodule Peridiod.Release do
             name: nil,
             version: nil,
             version_requirement: nil,
-            bundle_prn: nil,
-            binaries: nil
+            bundle: nil
 
   @type t() :: %__MODULE__{
           prn: String.t(),
           name: String.t(),
           version: Version.t(),
           version_requirement: Version.Requirement.t(),
-          bundle_prn: String.t(),
-          binaries: [Binary.t()]
+          bundle: Bundle.t()
         }
 
   defimpl Jason.Encoder, for: Release do
@@ -39,44 +39,22 @@ defmodule Peridiod.Release do
         end
 
       release_metadata
-      |> Map.take([:prn, :name, :version_requirement, :bundle_prn])
+      |> Map.take([:prn, :name, :version_requirement])
       |> Map.put(:version, version)
       |> Map.put(:version_requirement, version_requirement)
+      |> Map.put(:bundle_prn, release_metadata.bundle.prn)
       |> Jason.Encode.map(opts)
     end
   end
-
-  def metadata_from_cache(cache_pid \\ Cache, release_prn)
 
   def metadata_from_cache(cache_pid, release_prn) do
     manifest_file = Path.join(["release", release_prn, "manifest"])
 
     with {:ok, json} <- Cache.read(cache_pid, manifest_file),
-         {:ok, release_metadata} <- metadata_from_json(json) do
-      binaries =
-        case Cache.ls(cache_pid, Path.join(["bundle", release_metadata.bundle_prn])) do
-          {:ok, binary_prns} ->
-            binary_prns
-            |> Enum.reduce([], fn dirname, acc ->
-              case Binary.metadata_from_cache(cache_pid, dirname) do
-                {:ok, binary_metadata} -> [binary_metadata | acc]
-                _error -> acc
-              end
-            end)
-
-          _error ->
-            []
-        end
-
-      {:ok, Map.put(release_metadata, :binaries, binaries)}
-    end
-  end
-
-  def metadata_from_json(json) when is_binary(json) do
-    with {:ok, map} <- Jason.decode(json) do
+         {:ok, map} <- Jason.decode(json) do
+      bundle_metadata = bundle_metadata_from_cache(cache_pid, map["bundle_prn"])
+      map = Map.put(map, "bundle", bundle_metadata)
       {:ok, metadata_from_map(map)}
-    else
-      error -> error
     end
   end
 
@@ -98,7 +76,7 @@ defmodule Peridiod.Release do
       name: release_metadata["name"],
       version: version,
       version_requirement: version_requirement,
-      bundle_prn: release_metadata["bundle_prn"]
+      bundle: release_metadata["bundle"]
     }
   end
 
@@ -106,11 +84,11 @@ defmodule Peridiod.Release do
   Recursively parse a release manifest into structs
   """
   @spec metadata_from_manifest(map()) :: {:ok, t()}
-  def metadata_from_manifest(%{
-        "release" => release_metadata,
-        "manifest" => binaries,
-        "bundle" => bundle
-      }) do
+  def metadata_from_manifest(
+        %{
+          "release" => release_metadata
+        } = manifest
+      ) do
     version =
       case release_metadata["version"] do
         nil -> nil
@@ -123,46 +101,37 @@ defmodule Peridiod.Release do
         version_requirement -> Version.parse_requirement!(version_requirement)
       end
 
+    bundle =
+      case Bundle.metadata_from_manifest(manifest) do
+        {:ok, bundle} ->
+          bundle
+
+        error ->
+          Logger.error("Error loading bundle from manifest: #{inspect(error)}")
+          nil
+      end
+
     {:ok,
      %__MODULE__{
        prn: release_metadata["prn"],
        name: release_metadata["name"],
        version: version,
        version_requirement: version_requirement,
-       bundle_prn: bundle["prn"],
-       binaries: Enum.map(binaries, &Binary.metadata_from_manifest/1)
+       bundle: bundle
      }}
   end
 
   def metadata_to_cache(
         cache_pid \\ Cache,
-        %__MODULE__{prn: release_prn, binaries: binaries} = release_metadata
+        %__MODULE__{prn: release_prn, bundle: bundle} = release_metadata
       ) do
     release_json = Jason.encode!(release_metadata)
 
     manifest_file = Path.join(["release", release_prn, "manifest"])
 
-    case Cache.write(cache_pid, manifest_file, release_json) do
-      :ok ->
-        bundle_path = Path.join(["bundle", release_metadata.bundle_prn])
-
-        Enum.each(binaries, fn binary_metadata ->
-          Binary.metadata_to_cache(cache_pid, binary_metadata)
-          target = Binary.cache_dir(binary_metadata)
-
-          link =
-            Path.join([
-              bundle_path,
-              "#{binary_metadata.prn}:#{Base.encode16(binary_metadata.custom_metadata_hash, case: :lower)}"
-            ])
-
-          Cache.ln_s(cache_pid, target, link)
-        end)
-
-        :ok
-
-      error ->
-        error
+    with :ok <- Cache.write(cache_pid, manifest_file, release_json),
+         :ok <- Bundle.metadata_to_cache(cache_pid, bundle) do
+      :ok
     end
   end
 
@@ -190,12 +159,6 @@ defmodule Peridiod.Release do
     Cache.write(cache_pid, stamp_file, stamp_utc_now())
   end
 
-  def filter_binaries_by_targets(%__MODULE__{binaries: binaries}, []), do: binaries
-
-  def filter_binaries_by_targets(%__MODULE__{binaries: binaries}, targets) do
-    Enum.filter(binaries, &(&1.target in [nil, "" | targets]))
-  end
-
   def kv_progress(kv_pid \\ KV, %__MODULE__{prn: prn} = release_metadata) when not is_nil(prn) do
     version =
       case release_metadata.version do
@@ -214,23 +177,42 @@ defmodule Peridiod.Release do
 
     KV.get_all_and_update(kv_pid, fn kv ->
       rel_progress = Map.get(kv, "peridio_rel_progress", "")
+      bun_progress = Map.get(kv, "peridio_bun_progress", "")
+      ovr_progress = Map.get(kv, "peridio_ovr_progress", "")
       vsn_progress = Map.get(kv, "peridio_vsn_progress", "")
       bin_progress = Map.get(kv, "peridio_bin_progress", "")
 
       rel_current = Map.get(kv, "peridio_rel_current", "")
+      bun_current = Map.get(kv, "peridio_bun_current", "")
+      ovr_current = Map.get(kv, "peridio_ovr_current", "")
       vsn_current = Map.get(kv, "peridio_vsn_current", "")
       bin_current = Map.get(kv, "peridio_bin_current", "")
 
       kv
       |> Map.put("peridio_rel_previous", rel_current)
+      |> Map.put("peridio_rel_previous", bun_current)
+      |> Map.put("peridio_ovr_previous", ovr_current)
       |> Map.put("peridio_vsn_previous", vsn_current)
       |> Map.put("peridio_bin_previous", bin_current)
       |> Map.put("peridio_rel_current", rel_progress)
+      |> Map.put("peridio_bun_current", bun_progress)
+      |> Map.put("peridio_ovr_current", ovr_progress)
       |> Map.put("peridio_vsn_current", vsn_progress)
       |> Map.put("peridio_bin_current", bin_progress)
       |> Map.put("peridio_rel_progress", "")
+      |> Map.put("peridio_bun_progress", "")
+      |> Map.put("peridio_ovr_progress", "")
       |> Map.put("peridio_vsn_progress", "")
       |> Map.put("peridio_bin_progress", "")
     end)
+  end
+
+  defp bundle_metadata_from_cache(_cache_pid, nil), do: nil
+
+  defp bundle_metadata_from_cache(cache_pid, bundle_prn) do
+    case Bundle.metadata_from_cache(cache_pid, bundle_prn) do
+      {:ok, bundle_metadata} -> bundle_metadata
+      _ -> nil
+    end
   end
 end

--- a/test/peridiod/binary_test.exs
+++ b/test/peridiod/binary_test.exs
@@ -9,7 +9,7 @@ defmodule Peridiod.BinaryTest do
     setup :start_cache
 
     test "metadata write cache", %{cache_pid: cache_pid, release_metadata: release_metadata} do
-      binary_metadata = List.first(release_metadata.binaries)
+      binary_metadata = List.first(release_metadata.bundle.binaries)
       assert :ok = Binary.metadata_to_cache(cache_pid, binary_metadata)
     end
 
@@ -17,7 +17,7 @@ defmodule Peridiod.BinaryTest do
       cache_pid: cache_pid,
       release_metadata: release_metadata
     } do
-      binary_metadata = List.first(release_metadata.binaries)
+      binary_metadata = List.first(release_metadata.bundle.binaries)
 
       %Binary{
         prn: binary_prn,
@@ -53,7 +53,7 @@ defmodule Peridiod.BinaryTest do
       cache_pid: cache_pid,
       release_metadata: release_metadata
     } do
-      binary_metadata = List.first(release_metadata.binaries)
+      binary_metadata = List.first(release_metadata.bundle.binaries)
 
       assert {:error, :enoent} =
                Binary.metadata_from_cache(
@@ -67,7 +67,7 @@ defmodule Peridiod.BinaryTest do
       cache_dir: cache_dir,
       release_metadata: release_metadata
     } do
-      binary_metadata = List.first(release_metadata.binaries)
+      binary_metadata = List.first(release_metadata.bundle.binaries)
       Binary.metadata_to_cache(cache_pid, binary_metadata)
 
       signature_file =
@@ -91,7 +91,7 @@ defmodule Peridiod.BinaryTest do
       cache_dir: cache_dir,
       release_metadata: release_metadata
     } do
-      binary_metadata = List.first(release_metadata.binaries)
+      binary_metadata = List.first(release_metadata.bundle.binaries)
       Binary.metadata_to_cache(cache_pid, binary_metadata)
       Binary.stamp_installed(cache_pid, binary_metadata)
 
@@ -116,7 +116,7 @@ defmodule Peridiod.BinaryTest do
       kv_pid: kv_pid,
       release_metadata: release_metadata
     } do
-      binary_metadata = List.first(release_metadata.binaries)
+      binary_metadata = List.first(release_metadata.bundle.binaries)
       Binary.metadata_to_cache(cache_pid, binary_metadata)
       assert {:ok, _contents} = Binary.put_kv_installed(kv_pid, binary_metadata, :progress)
       kv_installed = Binary.get_all_kv_installed(kv_pid, :progress)
@@ -137,7 +137,7 @@ defmodule Peridiod.BinaryTest do
       kv_pid: kv_pid,
       release_metadata: release_metadata
     } do
-      binary_metadata = List.first(release_metadata.binaries)
+      binary_metadata = List.first(release_metadata.bundle.binaries)
       Binary.metadata_to_cache(cache_pid, binary_metadata)
       Binary.put_kv_installed(kv_pid, binary_metadata, :progress)
       Binary.pop_kv_installed(kv_pid, binary_metadata, :progress)

--- a/test/peridiod/bundle_test.exs
+++ b/test/peridiod/bundle_test.exs
@@ -1,0 +1,82 @@
+defmodule Peridiod.BundleTest do
+  use PeridiodTest.Case
+  doctest Peridiod.Bundle
+
+  alias Peridiod.{Bundle, Binary}
+
+  test "bundle parse manifest", %{release_manifest: release_manifest} do
+    assert {:ok, %Bundle{}} = Bundle.metadata_from_manifest(release_manifest)
+  end
+
+  describe "bundle encode decode" do
+    setup :load_bundle_metadata_from_manifest
+    setup :start_cache
+
+    test "metadata write cache", %{cache_pid: cache_pid, bundle_metadata: bundle_metadata} do
+      assert :ok = Bundle.metadata_to_cache(cache_pid, bundle_metadata)
+    end
+
+    test "metadata read cache", %{
+      cache_pid: cache_pid,
+      bundle_metadata:
+        %Bundle{
+          prn: prn
+        } = bundle_metadata
+    } do
+      Bundle.metadata_to_cache(cache_pid, bundle_metadata)
+
+      [
+        %Binary{
+          prn: binary_prn,
+          name: binary_name,
+          version: binary_version,
+          hash: binary_hash,
+          custom_metadata: custom_metadata,
+          target: target,
+          signatures: signatures,
+          size: size
+        }
+      ] = bundle_metadata.binaries
+
+      assert {:ok,
+              %Bundle{
+                prn: ^prn,
+                binaries: [
+                  %Binary{
+                    prn: ^binary_prn,
+                    name: ^binary_name,
+                    version: ^binary_version,
+                    hash: ^binary_hash,
+                    custom_metadata: ^custom_metadata,
+                    target: ^target,
+                    signatures: ^signatures,
+                    size: ^size
+                  }
+                ]
+              }} = Bundle.metadata_from_cache(cache_pid, bundle_metadata.prn)
+    end
+
+    test "metadata read cache missing", %{
+      cache_pid: cache_pid,
+      cache_dir: cache_dir,
+      bundle_metadata: bundle_metadata
+    } do
+      Bundle.metadata_to_cache(cache_pid, bundle_metadata)
+      File.rm_rf(cache_dir)
+      assert {:error, :enoent} = Bundle.metadata_from_cache(cache_pid, bundle_metadata.prn)
+    end
+
+    test "metadata read cache invalid signature", %{
+      cache_pid: cache_pid,
+      cache_dir: cache_dir,
+      bundle_metadata: bundle_metadata
+    } do
+      Bundle.metadata_to_cache(cache_pid, bundle_metadata)
+      signature_file = Path.join([cache_dir, "bundle", bundle_metadata.prn, "manifest.sig"])
+      File.write(signature_file, "")
+
+      assert {:error, :invalid_signature} =
+               Bundle.metadata_from_cache(cache_pid, bundle_metadata.prn)
+    end
+  end
+end

--- a/test/peridiod/release/server_test.exs
+++ b/test/peridiod/release/server_test.exs
@@ -11,7 +11,7 @@ defmodule Peridiod.Release.ServerTest do
 
     test "cache trusted signatures", %{
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries}
+      release_metadata: %Release{bundle: %{binaries: binaries}}
     } do
       binary_metadata = List.first(binaries)
       signing_key = List.first(binary_metadata.signatures).signing_key
@@ -23,7 +23,7 @@ defmodule Peridiod.Release.ServerTest do
 
     test "cache untrusted signatures", %{
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries}
+      release_metadata: %Release{bundle: %{binaries: binaries}}
     } do
       binary_metadata = List.first(binaries)
 
@@ -33,7 +33,7 @@ defmodule Peridiod.Release.ServerTest do
 
     test "install untrusted signatures", %{
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries}
+      release_metadata: %Release{bundle: %{binaries: binaries}}
     } do
       binary_metadata = List.first(binaries)
 
@@ -44,7 +44,7 @@ defmodule Peridiod.Release.ServerTest do
     test "already cached", %{
       cache_pid: cache_pid,
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries}
+      release_metadata: %Release{bundle: %{binaries: binaries}}
     } do
       binary_metadata = List.first(binaries)
       :ok = Binary.metadata_to_cache(cache_pid, binary_metadata)
@@ -59,7 +59,7 @@ defmodule Peridiod.Release.ServerTest do
     test "already installed", %{
       cache_pid: cache_pid,
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries}
+      release_metadata: %Release{bundle: %{binaries: binaries}}
     } do
       binary_metadata = List.first(binaries)
       :ok = Binary.metadata_to_cache(cache_pid, binary_metadata)
@@ -80,7 +80,7 @@ defmodule Peridiod.Release.ServerTest do
 
     test "cache trusted signatures", %{
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries} = release_metadata
+      release_metadata: %Release{bundle: %{binaries: binaries}} = release_metadata
     } do
       binary_metadata = List.first(binaries)
       signing_key = List.first(binary_metadata.signatures).signing_key
@@ -109,7 +109,7 @@ defmodule Peridiod.Release.ServerTest do
     test "already cached", %{
       cache_pid: cache_pid,
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries} = release_metadata
+      release_metadata: %Release{bundle: %{binaries: binaries}} = release_metadata
     } do
       binary_metadata = List.first(binaries)
       signing_key = List.first(binary_metadata.signatures).signing_key
@@ -130,7 +130,7 @@ defmodule Peridiod.Release.ServerTest do
     test "file from cache", %{
       cache_pid: cache_pid,
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries}
+      release_metadata: %Release{bundle: %{binaries: binaries}}
     } do
       binary_metadata = List.first(binaries)
       cache_file = Binary.cache_file(binary_metadata)
@@ -156,7 +156,7 @@ defmodule Peridiod.Release.ServerTest do
     test "file url to cache", %{
       cache_pid: cache_pid,
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries}
+      release_metadata: %Release{bundle: %{binaries: binaries}}
     } do
       binary_metadata = List.first(binaries)
       cache_file = Binary.cache_file(binary_metadata)
@@ -184,7 +184,7 @@ defmodule Peridiod.Release.ServerTest do
     test "file from cache", %{
       cache_pid: cache_pid,
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries} = release_metadata
+      release_metadata: %Release{bundle: %{binaries: binaries}} = release_metadata
     } do
       binary_metadata = List.first(binaries)
       cache_file = Binary.cache_file(binary_metadata)
@@ -211,7 +211,7 @@ defmodule Peridiod.Release.ServerTest do
     test "from downloader", %{
       cache_pid: cache_pid,
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries} = release_metadata
+      release_metadata: %Release{bundle: %{binaries: binaries}} = release_metadata
     } do
       binary_metadata = List.first(binaries)
       cache_file = Binary.cache_file(binary_metadata)
@@ -230,7 +230,7 @@ defmodule Peridiod.Release.ServerTest do
     test "reboot", %{
       cache_pid: cache_pid,
       release_server_pid: release_server_pid,
-      release_metadata: %Release{binaries: binaries} = release_metadata
+      release_metadata: %Release{bundle: %{binaries: binaries}} = release_metadata
     } do
       binary_metadata = List.first(binaries)
       cache_file = Binary.cache_file(binary_metadata)
@@ -240,7 +240,8 @@ defmodule Peridiod.Release.ServerTest do
         |> update_in(["peridiod", "reboot_required"], fn _ -> true end)
 
       binary_metadata = %{binary_metadata | custom_metadata: custom_metadata}
-      release_metadata = %{release_metadata | binaries: [binary_metadata]}
+      bundle_metadata = %{release_metadata.bundle | binaries: [binary_metadata]}
+      release_metadata = %{release_metadata | bundle: bundle_metadata}
 
       false = Binary.cached?(cache_pid, binary_metadata)
       false = Cache.exists?(cache_pid, cache_file)
@@ -258,7 +259,7 @@ defmodule Peridiod.Release.ServerTest do
   def cache_binary(
         %{
           cache_pid: cache_pid,
-          release_metadata: %Release{binaries: binaries}
+          release_metadata: %Release{bundle: %{binaries: binaries}}
         } = context
       ) do
     binary_metadata = List.first(binaries)

--- a/test/peridiod/release_test.exs
+++ b/test/peridiod/release_test.exs
@@ -21,7 +21,7 @@ defmodule Peridiod.ReleaseTest do
       release_metadata:
         %Release{
           prn: prn,
-          bundle_prn: bundle_prn,
+          bundle: _bundle,
           name: name,
           version: version,
           version_requirement: version_requirement
@@ -40,28 +40,31 @@ defmodule Peridiod.ReleaseTest do
           signatures: signatures,
           size: size
         }
-      ] = release_metadata.binaries
+      ] = release_metadata.bundle.binaries
+
+      release_metadata = Release.metadata_from_cache(cache_pid, release_metadata.prn)
 
       assert {:ok,
               %Release{
                 prn: ^prn,
-                bundle_prn: ^bundle_prn,
+                bundle: %{
+                  binaries: [
+                    %Binary{
+                      prn: ^binary_prn,
+                      name: ^binary_name,
+                      version: ^binary_version,
+                      hash: ^binary_hash,
+                      custom_metadata: ^custom_metadata,
+                      target: ^target,
+                      signatures: ^signatures,
+                      size: ^size
+                    }
+                  ]
+                },
                 name: ^name,
                 version: ^version,
-                version_requirement: ^version_requirement,
-                binaries: [
-                  %Binary{
-                    prn: ^binary_prn,
-                    name: ^binary_name,
-                    version: ^binary_version,
-                    hash: ^binary_hash,
-                    custom_metadata: ^custom_metadata,
-                    target: ^target,
-                    signatures: ^signatures,
-                    size: ^size
-                  }
-                ]
-              }} = Release.metadata_from_cache(cache_pid, release_metadata.prn)
+                version_requirement: ^version_requirement
+              }} = release_metadata
     end
 
     test "metadata read cache missing", %{

--- a/test/support/test_case.ex
+++ b/test/support/test_case.ex
@@ -2,7 +2,7 @@ defmodule PeridiodTest.Case do
   use ExUnit.CaseTemplate
 
   alias PeridiodPersistence.KV
-  alias Peridiod.{Cache, Release}
+  alias Peridiod.{Cache, Release, Bundle}
   alias PeridiodTest.StaticRouter
   alias Peridiod.TestFixtures
 
@@ -34,6 +34,11 @@ defmodule PeridiodTest.Case do
   def load_release_metadata_from_manifest(%{release_manifest: release_manifest} = context) do
     {:ok, release_metadata} = Release.metadata_from_manifest(release_manifest)
     Map.put(context, :release_metadata, release_metadata)
+  end
+
+  def load_bundle_metadata_from_manifest(%{release_manifest: release_manifest} = context) do
+    {:ok, bundle_metadata} = Bundle.metadata_from_manifest(release_manifest)
+    Map.put(context, :bundle_metadata, bundle_metadata)
   end
 
   def start_cache(context) do


### PR DESCRIPTION
Pull bundle information out of releases in preparation to apply them independently via bundle overrides. 