### PR TITLE
Allow Installers to specify their downloader module.

### DIFF
--- a/lib/peridiod/application.ex
+++ b/lib/peridiod/application.ex
@@ -17,7 +17,7 @@ defmodule Peridiod.Application do
     children = [
       {Cache, config},
       Binary.Installer.Supervisor,
-      Binary.Downloader.Supervisor,
+      Binary.StreamDownloader.Supervisor,
       Binary.CacheDownloader.Supervisor,
       {Release.Server, config}
     ]

--- a/lib/peridiod/binary/cache_downloader.ex
+++ b/lib/peridiod/binary/cache_downloader.ex
@@ -3,7 +3,7 @@ defmodule Peridiod.Binary.CacheDownloader do
 
   require Logger
 
-  alias Peridiod.Binary.Downloader
+  alias Peridiod.Binary.StreamDownloader
   alias Peridiod.{Cache, Binary}
 
   def child_spec(%Binary{prn: binary_prn} = binary_metadata, opts) do
@@ -34,7 +34,7 @@ defmodule Peridiod.Binary.CacheDownloader do
     fun = &send(pid, {:download_cache, &1})
 
     {:ok, downloader} =
-      Downloader.Supervisor.start_child(
+      StreamDownloader.Supervisor.start_child(
         binary_metadata.prn,
         binary_metadata.uri,
         fun
@@ -110,7 +110,7 @@ defmodule Peridiod.Binary.CacheDownloader do
   end
 
   def handle_info(msg, state) do
-    Logger.debug("CacheDownloader unhandled message: #{inspect(msg)}")
+    Logger.debug("Cache Downloader unhandled message: #{inspect(msg)}")
     {:noreply, state}
   end
 end

--- a/lib/peridiod/binary/installer.ex
+++ b/lib/peridiod/binary/installer.ex
@@ -5,7 +5,7 @@ defmodule Peridiod.Binary.Installer do
 
   alias PeridiodPersistence.KV
   alias Peridiod.{Binary, Cache}
-  alias Peridiod.Binary.{Installer, Downloader}
+  alias Peridiod.Binary.{Installer, CacheDownloader, StreamDownloader}
 
   defmodule State do
     defstruct cache_pid: Cache,
@@ -50,7 +50,7 @@ defmodule Peridiod.Binary.Installer do
     cache_pid = Map.get(opts, :cache_pid, Cache)
     kv_pid = Map.get(opts, :kv_pid, KV)
     callback = opts.callback
-    config = opts.config
+    config = Map.put(opts.config, :cache_pid, cache_pid)
 
     {:ok,
      %State{
@@ -135,7 +135,7 @@ defmodule Peridiod.Binary.Installer do
     |> installer_complete()
   end
 
-  def handle_info({:download_install, :start}, state) do
+  def handle_info({:download_stream, :start}, state) do
     state = %{state | hash_accumulator: :crypto.hash_init(:sha256)}
 
     apply(state.installer_mod, :install_init, [
@@ -148,7 +148,18 @@ defmodule Peridiod.Binary.Installer do
     |> installer_progress()
   end
 
-  def handle_info({:download_install, :complete}, state) do
+  def handle_info({:download_cache, :start}, state) do
+    apply(state.installer_mod, :install_init, [
+      state.binary_metadata,
+      state.installer_opts,
+      :download,
+      state.config
+    ])
+    |> installer_resp(state)
+    |> installer_progress()
+  end
+
+  def handle_info({:download_stream, :complete}, state) do
     hash = :crypto.hash_final(state.hash_accumulator)
     state = %{state | install_percent: 1.0, hash_accumulator: hash, bytes_streamed: 0}
     [signature] = state.binary_metadata.signatures
@@ -180,7 +191,18 @@ defmodule Peridiod.Binary.Installer do
     |> installer_complete()
   end
 
-  def handle_info({:download_install, {:error, reason}}, state) do
+  def handle_info({:download_cache, _binary_metadata, :complete}, state) do
+    apply(state.installer_mod, :install_finish, [
+      state.binary_metadata,
+      :valid_signature,
+      nil,
+      state.installer_state
+    ])
+    |> installer_resp(state)
+    |> installer_complete()
+  end
+
+  def handle_info({:download_stream, {:error, reason}}, state) do
     apply(state.installer_mod, :install_error, [
       state.binary_metadata,
       reason,
@@ -190,7 +212,17 @@ defmodule Peridiod.Binary.Installer do
     |> installer_error()
   end
 
-  def handle_info({:download_install, {:data, data}}, state) do
+  def handle_info({:download_cache, _binary_metadata, {:error, reason}}, state) do
+    apply(state.installer_mod, :install_error, [
+      state.binary_metadata,
+      reason,
+      state.installer_state
+    ])
+    |> installer_resp(state)
+    |> installer_error()
+  end
+
+  def handle_info({:download_stream, {:data, data}}, state) do
     hash = :crypto.hash_update(state.hash_accumulator, data)
     bytes_streamed = state.bytes_streamed + byte_size(data)
     install_percent = bytes_streamed / state.binary_metadata.size
@@ -209,6 +241,15 @@ defmodule Peridiod.Binary.Installer do
     ])
     |> installer_resp(state)
     |> installer_progress()
+  end
+
+  def handle_info({:download_cache, _binary_metadata, {:progress, percent_downloaded}}, state) do
+    state = %{
+      state
+      | install_percent: percent_downloaded
+    }
+
+    installer_progress({:noreply, state})
   end
 
   def handle_info(msg, state) do
@@ -279,6 +320,9 @@ defmodule Peridiod.Binary.Installer do
     {:stop, :normal, state}
   end
 
+  defp installer_mod(%Binary{custom_metadata: %{"peridiod" => %{"installer" => "cache"}}}),
+    do: Installer.Cache
+
   defp installer_mod(%Binary{custom_metadata: %{"peridiod" => %{"installer" => "fwup"}}}),
     do: Installer.Fwup
 
@@ -309,15 +353,35 @@ defmodule Peridiod.Binary.Installer do
   end
 
   defp do_install_from_download(state) do
+    downloader_mod =
+      apply(state.installer_mod, :install_downloader, [
+        state.binary_metadata,
+        state.installer_opts
+      ])
+
+    do_install_from_download_mod(downloader_mod, state)
+  end
+
+  defp do_install_from_download_mod(StreamDownloader, state) do
     pid = self()
-    send(self(), {:download_install, :start})
-    fun = &send(pid, {:download_install, &1})
+    send(self(), {:download_stream, :start})
+    fun = &send(pid, {:download_stream, &1})
 
     {:ok, _downloader} =
-      Downloader.Supervisor.start_child(
+      StreamDownloader.Supervisor.start_child(
         state.binary_metadata.prn,
         state.binary_metadata.uri,
         fun
+      )
+  end
+
+  defp do_install_from_download_mod(CacheDownloader, state) do
+    send(self(), {:download_cache, :start})
+
+    {:ok, _downloader} =
+      CacheDownloader.Supervisor.start_child(
+        state.binary_metadata,
+        %{config: state.config, cache_pid: state.cache_pid}
       )
   end
 

--- a/lib/peridiod/binary/installer/behaviour.ex
+++ b/lib/peridiod/binary/installer/behaviour.ex
@@ -3,16 +3,20 @@ defmodule Peridiod.Binary.Installer.Behaviour do
     quote do
       @behaviour Peridiod.Binary.Installer.Behaviour
 
+      def install_downloader(%Peridiod.Binary{}, _installer_opts) do
+        Peridiod.Binary.CacheDownloader
+      end
+
       def install_init(%Peridiod.Binary{}, _source, _config) do
         {:ok, %{}}
       end
 
-      def install_update(%Peridiod.Binary{}, data, state) do
-        {:ok, state}
-      end
-
       def install_update(%Peridiod.Binary{}, {:error, reason}, state) do
         {:error, reason, state}
+      end
+
+      def install_update(%Peridiod.Binary{}, data, state) do
+        {:ok, state}
       end
 
       def install_finish(%Peridiod.Binary{}, :invalid_signature, state) do
@@ -27,7 +31,8 @@ defmodule Peridiod.Binary.Installer.Behaviour do
         {:error, error, installer_state}
       end
 
-      defoverridable install_init: 3,
+      defoverridable install_downloader: 2,
+                     install_init: 3,
                      install_update: 3,
                      install_finish: 3,
                      install_info: 2,
@@ -36,10 +41,12 @@ defmodule Peridiod.Binary.Installer.Behaviour do
   end
 
   alias Peridiod.Binary
+  alias Peridiod.Binary.{CacheDownloader, StreamDownloader}
 
   @type installer_state :: any()
   @type installer_opts :: map()
 
+  @callback install_downloader(Binary.t(), installer_opts) :: StreamDownloader | CacheDownloader
   @callback install_init(Binary.t(), :cache | :download, installer_opts, installer_state()) ::
               {:ok, installer_state()} | {:error, reason :: any(), installer_state()}
   @callback install_update(Binary.t(), data :: binary(), installer_state()) ::

--- a/lib/peridiod/binary/installer/cache.ex
+++ b/lib/peridiod/binary/installer/cache.ex
@@ -1,0 +1,55 @@
+defmodule Peridiod.Binary.Installer.Cache do
+  @moduledoc """
+  Installer module for cache only packages
+  This is really only used for testing
+
+  custom_metadata
+  ```
+  {
+    "peridiod": {
+      "installer": "cache",
+      "installer_opts": {},
+      "reboot_required": false
+    }
+  }
+  ```
+  """
+
+  use Peridiod.Binary.Installer.Behaviour
+
+  alias Peridiod.{Binary, Cache}
+  alias Peridiod.Binary.CacheDownloader
+
+  require Logger
+
+  def install_downloader(_binary_metadata, _opts) do
+    CacheDownloader
+  end
+
+  def install_init(
+        _binary_metadata,
+        opts,
+        _source,
+        config
+      ) do
+    {:ok, {opts, config}}
+  end
+
+  def install_finish(binary_metadata, :valid_signature, _hash, {_opts, config}) do
+    cache_file_path = Binary.cache_file(binary_metadata)
+
+    case Cache.exists?(config.cache_pid, cache_file_path) do
+      true ->
+        {:stop, :normal, nil}
+
+      false ->
+        Binary.cache_rm(config.cache_pid, binary_metadata)
+        {:error, :invalid_cache, nil}
+    end
+  end
+
+  def install_finish(binary_metadata, invalid, _hash, {_opts, config}) do
+    Binary.cache_rm(config.cache_pid, binary_metadata)
+    {:error, invalid, nil}
+  end
+end

--- a/lib/peridiod/binary/installer/file.ex
+++ b/lib/peridiod/binary/installer/file.ex
@@ -20,6 +20,11 @@ defmodule Peridiod.Binary.Installer.File do
   use Peridiod.Binary.Installer.Behaviour
 
   alias Peridiod.Binary
+  alias Peridiod.Binary.StreamDownloader
+
+  def install_downloader(_binary_metadata, _opts) do
+    StreamDownloader
+  end
 
   def install_init(
         %Binary{

--- a/lib/peridiod/binary/installer/fwup.ex
+++ b/lib/peridiod/binary/installer/fwup.ex
@@ -24,10 +24,15 @@ defmodule Peridiod.Binary.Installer.Fwup do
   use Peridiod.Binary.Installer.Behaviour
 
   alias PeridiodPersistence.KV
+  alias Peridiod.Binary.StreamDownloader
   alias Peridiod.Utils
   alias __MODULE__
 
   require Logger
+
+  def install_downloader(_binary_metadata, _opts) do
+    StreamDownloader
+  end
 
   def install_init(
         _binary_metadata,

--- a/lib/peridiod/binary/installer/opkg.ex
+++ b/lib/peridiod/binary/installer/opkg.ex
@@ -20,58 +20,47 @@ defmodule Peridiod.Binary.Installer.Opkg do
 
   use Peridiod.Binary.Installer.Behaviour
 
-  alias Peridiod.{Binary, Utils}
+  alias Peridiod.{Binary, Utils, Cache}
+  alias Peridiod.Binary.CacheDownloader
+
+  def install_downloader(_binary_metadata, _opts) do
+    CacheDownloader
+  end
 
   def install_init(
-        binary_metadata,
+        _binary_metadata,
         opts,
         _source,
-        _config
+        config
       ) do
     case Utils.exec_installed?(@exec) do
       false ->
         {:error,
-         "Unable to locate executable #{@exec} which is required to install with the RPM installer"}
+         "Unable to locate executable #{@exec} which is required to install with the opkg installer",
+         nil}
 
       true ->
-        do_init(binary_metadata, opts)
+        {:ok, {opts, config}}
     end
   end
 
-  def install_update(_binary_metadata, data, {cache_file, opts}) do
-    File.write(cache_file, data, [:append, :binary])
-    {:ok, {cache_file, opts}}
-  end
-
-  def install_finish(_binary_metadata, :valid_signature, _hash, {cache_file, opts}) do
+  def install_finish(binary_metadata, :valid_signature, _hash, {opts, config}) do
     extra_args = opts["extra_args"] || []
+    cache_file_path = Binary.cache_file(binary_metadata)
+    cache_file = Cache.abs_path(config.cache_pid, cache_file_path)
 
     case System.cmd(@exec, ["install", cache_file] ++ extra_args) do
       {_result, 0} ->
-        File.rm(cache_file)
         {:stop, :normal, nil}
 
       {error, _} ->
-        File.rm(cache_file)
+        Binary.cache_rm(config.cache_pid, binary_metadata)
         {:error, error, nil}
     end
   end
 
-  def install_finish(_binary_metadata, invalid, _hash, {cache_file, _opts}) do
-    File.rm(cache_file)
+  def install_finish(binary_metadata, invalid, _hash, {_opts, config}) do
+    Binary.cache_rm(config.cache_pid, binary_metadata)
     {:error, invalid, nil}
-  end
-
-  defp do_init(binary_metadata, opts) do
-    cache_dir = Binary.cache_dir(binary_metadata)
-
-    with :ok <- File.mkdir_p(cache_dir),
-         {:ok, id} <- Binary.id_from_prn(binary_metadata.prn) do
-      cache_file = Path.join([cache_dir, id])
-      {:ok, {cache_file, opts}}
-    else
-      {:error, error} ->
-        {:error, error, nil}
-    end
   end
 end

--- a/lib/peridiod/binary/installer/rpm.ex
+++ b/lib/peridiod/binary/installer/rpm.ex
@@ -20,58 +20,47 @@ defmodule Peridiod.Binary.Installer.Rpm do
 
   use Peridiod.Binary.Installer.Behaviour
 
-  alias Peridiod.{Binary, Utils}
+  alias Peridiod.{Binary, Utils, Cache}
+  alias Peridiod.Binary.CacheDownloader
+
+  def install_downloader(_binary_metadata, _opts) do
+    CacheDownloader
+  end
 
   def install_init(
-        binary_metadata,
+        _binary_metadata,
         opts,
         _source,
-        _config
+        config
       ) do
     case Utils.exec_installed?(@exec) do
       false ->
         {:error,
-         "Unable to locate executable #{@exec} which is required to install with the RPM installer"}
+         "Unable to locate executable #{@exec} which is required to install with the rpm installer",
+         nil}
 
       true ->
-        do_init(binary_metadata, opts)
+        {:ok, {opts, config}}
     end
   end
 
-  def install_update(_binary_metadata, data, {cache_file, opts}) do
-    File.write(cache_file, data, [:append, :binary])
-    {:ok, {cache_file, opts}}
-  end
-
-  def install_finish(_binary_metadata, :valid_signature, _hash, {cache_file, opts}) do
+  def install_finish(binary_metadata, :valid_signature, _hash, {opts, config}) do
     extra_args = opts["extra_args"] || []
+    cache_file_path = Binary.cache_file(binary_metadata)
+    cache_file = Cache.abs_path(config.cache_pid, cache_file_path)
 
     case System.cmd(@exec, ["install", "-y", cache_file] ++ extra_args) do
       {_result, 0} ->
-        File.rm(cache_file)
         {:stop, :normal, nil}
 
       {error, _} ->
-        File.rm(cache_file)
+        Binary.cache_rm(config.cache_pid, binary_metadata)
         {:error, error, nil}
     end
   end
 
-  def install_finish(_binary_metadata, invalid, _hash, {cache_file, _opts}) do
-    File.rm(cache_file)
+  def install_finish(binary_metadata, invalid, _hash, {_opts, config}) do
+    Binary.cache_rm(config.cache_pid, binary_metadata)
     {:error, invalid, nil}
-  end
-
-  defp do_init(binary_metadata, opts) do
-    cache_dir = Binary.cache_dir(binary_metadata)
-
-    with :ok <- File.mkdir_p(cache_dir),
-         {:ok, id} <- Binary.id_from_prn(binary_metadata.prn) do
-      cache_file = Path.join([cache_dir, id])
-      {:ok, {cache_file, opts}}
-    else
-      {:error, error} ->
-        {:error, error, nil}
-    end
   end
 end

--- a/lib/peridiod/binary/installer/swupdate.ex
+++ b/lib/peridiod/binary/installer/swupdate.ex
@@ -20,61 +20,50 @@ defmodule Peridiod.Binary.Installer.SWUpdate do
 
   use Peridiod.Binary.Installer.Behaviour
 
-  alias Peridiod.{Binary, Utils}
+  alias Peridiod.{Binary, Utils, Cache}
+  alias Peridiod.Binary.CacheDownloader
 
   require Logger
 
+  def install_downloader(_binary_metadata, _opts) do
+    CacheDownloader
+  end
+
   def install_init(
-        binary_metadata,
+        _binary_metadata,
         opts,
         _source,
-        _config
+        config
       ) do
     case Utils.exec_installed?(@exec) do
       false ->
         {:error,
-         "Unable to locate executable #{@exec} which is required to install with the RPM installer"}
+         "Unable to locate executable #{@exec} which is required to install with the swupdate installer",
+         nil}
 
       true ->
-        do_init(binary_metadata, opts)
+        {:ok, {opts, config}}
     end
   end
 
-  def install_update(_binary_metadata, data, {cache_file, opts}) do
-    File.write(cache_file, data, [:append, :binary])
-    {:ok, {cache_file, opts}}
-  end
-
-  def install_finish(_binary_metadata, :valid_signature, _hash, {cache_file, opts}) do
+  def install_finish(binary_metadata, :valid_signature, _hash, {opts, config}) do
     extra_args = opts["extra_args"] || []
+    cache_file_path = Binary.cache_file(binary_metadata)
+    cache_file = Cache.abs_path(config.cache_pid, cache_file_path)
 
     case System.cmd("swupdate", ["-i", cache_file] ++ extra_args) do
       {_result, 0} ->
-        File.rm(cache_file)
         {:stop, :normal, nil}
 
       {error, _} ->
         Logger.debug("[Installer SWupdate] Install Error: #{inspect(error)}")
-        File.rm(cache_file)
+        Binary.cache_rm(config.cache_pid, binary_metadata)
         {:error, error, nil}
     end
   end
 
-  def install_finish(_binary_metadata, invalid, _hash, {cache_file, _opts}) do
-    File.rm(cache_file)
+  def install_finish(binary_metadata, invalid, _hash, {_opts, config}) do
+    Binary.cache_rm(config.cache_pid, binary_metadata)
     {:error, invalid, nil}
-  end
-
-  defp do_init(binary_metadata, opts) do
-    cache_dir = Binary.cache_dir(binary_metadata)
-
-    with :ok <- File.mkdir_p(cache_dir),
-         {:ok, id} <- Binary.id_from_prn(binary_metadata.prn) do
-      cache_file = Path.join([cache_dir, id])
-      {:ok, {cache_file, opts}}
-    else
-      {:error, error} ->
-        {:error, error, nil}
-    end
   end
 end

--- a/lib/peridiod/binary/stream_downloader/retry_config.ex
+++ b/lib/peridiod/binary/stream_downloader/retry_config.ex
@@ -1,6 +1,6 @@
-defmodule Peridiod.Binary.Downloader.RetryConfig do
+defmodule Peridiod.Binary.StreamDownloader.RetryConfig do
   @moduledoc """
-  Configuration structure for how the Downloader server will
+  Configuration structure for how the StreamDownloader server will
   handle disconnects, errors, timeouts etc
   """
 

--- a/lib/peridiod/binary/stream_downloader/supervisor.ex
+++ b/lib/peridiod/binary/stream_downloader/supervisor.ex
@@ -1,20 +1,20 @@
-defmodule Peridiod.Binary.Downloader.Supervisor do
+defmodule Peridiod.Binary.StreamDownloader.Supervisor do
   use DynamicSupervisor
 
-  alias Peridiod.Binary.Downloader
-  alias Peridiod.Binary.Downloader.RetryConfig
+  alias Peridiod.Binary.StreamDownloader
+  alias Peridiod.Binary.StreamDownloader.RetryConfig
 
   def start_link(init_arg) do
     DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
 
   def start_child(id, %URI{} = uri, fun) do
-    child_spec = Downloader.child_spec(id, uri, fun, %RetryConfig{})
+    child_spec = StreamDownloader.child_spec(id, uri, fun, %RetryConfig{})
     DynamicSupervisor.start_child(__MODULE__, child_spec)
   end
 
   def start_child(id, url, fun) when is_binary(url) do
-    child_spec = Downloader.child_spec(id, URI.parse(url), fun, %RetryConfig{})
+    child_spec = StreamDownloader.child_spec(id, URI.parse(url), fun, %RetryConfig{})
     DynamicSupervisor.start_child(__MODULE__, child_spec)
   end
 

--- a/lib/peridiod/binary/stream_downloader/timeout_calculation.ex
+++ b/lib/peridiod/binary/stream_downloader/timeout_calculation.ex
@@ -1,4 +1,4 @@
-defmodule Peridiod.Binary.Downloader.TimeoutCalculation do
+defmodule Peridiod.Binary.StreamDownloader.TimeoutCalculation do
   @moduledoc """
   Pure functions for dealing with timeouts
   """

--- a/lib/peridiod/bundle.ex
+++ b/lib/peridiod/bundle.ex
@@ -3,7 +3,7 @@ defmodule Peridiod.Bundle do
 
   import Peridiod.Utils, only: [stamp_utc_now: 0]
 
-  @cache_dir "bundle"
+  @cache_path "bundle"
   @stamp_cached ".stamp_cached"
   @stamp_installed ".stamp_installed"
 
@@ -24,11 +24,11 @@ defmodule Peridiod.Bundle do
   end
 
   def metadata_from_cache(cache_pid, bundle_prn) do
-    manifest_file = Path.join([cache_dir(bundle_prn), "manifest"])
+    manifest_file = Path.join([cache_path(bundle_prn), "manifest"])
 
     with {:ok, json} <- Cache.read(cache_pid, manifest_file),
          {:ok, bundle_metadata} <- metadata_from_json(json) do
-      binaries_dir = Path.join(cache_dir(bundle_metadata), "binaries")
+      binaries_dir = Path.join(cache_path(bundle_metadata), "binaries")
 
       binaries =
         case Cache.ls(cache_pid, binaries_dir) do
@@ -89,7 +89,7 @@ defmodule Peridiod.Bundle do
     with :ok <- Cache.write(cache_pid, manifest_file, bundle_json) do
       Enum.each(binaries, fn binary_metadata ->
         Binary.metadata_to_cache(cache_pid, binary_metadata)
-        target = Binary.cache_dir(binary_metadata)
+        target = Binary.cache_path(binary_metadata)
 
         link =
           Path.join([
@@ -104,26 +104,26 @@ defmodule Peridiod.Bundle do
     end
   end
 
-  def cache_dir(%__MODULE__{prn: bundle_prn}) do
-    cache_dir(bundle_prn)
+  def cache_path(%__MODULE__{prn: bundle_prn}) do
+    cache_path(bundle_prn)
   end
 
-  def cache_dir(bundle_prn) when is_binary(bundle_prn) do
-    Path.join([@cache_dir, bundle_prn])
+  def cache_path(bundle_prn) when is_binary(bundle_prn) do
+    Path.join([@cache_path, bundle_prn])
   end
 
   def installed?(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
-    stamp_file = Path.join([cache_dir(release_metadata), @stamp_installed])
+    stamp_file = Path.join([cache_path(release_metadata), @stamp_installed])
     Cache.exists?(cache_pid, stamp_file)
   end
 
   def stamp_cached(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
-    stamp_file = Path.join([cache_dir(release_metadata), @stamp_cached])
+    stamp_file = Path.join([cache_path(release_metadata), @stamp_cached])
     Cache.write(cache_pid, stamp_file, stamp_utc_now())
   end
 
   def stamp_installed(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
-    stamp_file = Path.join([cache_dir(release_metadata), @stamp_installed])
+    stamp_file = Path.join([cache_path(release_metadata), @stamp_installed])
     Cache.write(cache_pid, stamp_file, stamp_utc_now())
   end
 

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -44,6 +44,14 @@ defmodule Peridiod.Cache do
     GenServer.call(pid_or_name, {:ls, path})
   end
 
+  def abs_path(pid_or_name \\ __MODULE__, file) do
+    GenServer.call(pid_or_name, {:abs_path, file})
+  end
+
+  def rm(pid_or_name \\ __MODULE__, file) do
+    GenServer.call(pid_or_name, {:rm, file})
+  end
+
   def init(config) do
     private_key = config.cache_private_key
     public_key = config.cache_public_key
@@ -152,6 +160,16 @@ defmodule Peridiod.Cache do
   def handle_call({:ls, path}, _from, state) do
     path = Path.join([state.path, path])
     {:reply, File.ls(path), state}
+  end
+
+  def handle_call({:abs_path, file}, _from, state) do
+    path = Path.join([state.path, file])
+    {:reply, path, state}
+  end
+
+  def handle_call({:rm, file}, _from, state) do
+    path = Path.join([state.path, file])
+    {:reply, File.rm(path), state}
   end
 
   defp do_write(file, content, %{

--- a/lib/peridiod/distribution/server.ex
+++ b/lib/peridiod/distribution/server.ex
@@ -10,7 +10,7 @@ defmodule Peridiod.Distribution.Server do
   use GenServer
 
   alias Peridiod.{Client, Distribution}
-  alias Peridiod.Binary.{Downloader, Downloader.Supervisor, Installer.Fwup}
+  alias Peridiod.Binary.{StreamDownloader, StreamDownloader.Supervisor, Installer.Fwup}
   alias PeridiodPersistence.KV
 
   require Logger
@@ -268,7 +268,7 @@ defmodule Peridiod.Distribution.Server do
     fun = &send(pid, {:download, &1})
 
     {:ok, download} =
-      Downloader.Supervisor.start_child(
+      StreamDownloader.Supervisor.start_child(
         distribution.firmware_meta.uuid,
         distribution.firmware_url,
         fun

--- a/lib/peridiod/release.ex
+++ b/lib/peridiod/release.ex
@@ -6,7 +6,7 @@ defmodule Peridiod.Release do
 
   require Logger
 
-  @cache_dir "release"
+  @cache_path "release"
   @stamp_cached ".stamp_cached"
   @stamp_installed ".stamp_installed"
 
@@ -136,26 +136,26 @@ defmodule Peridiod.Release do
   end
 
   def cached?(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
-    stamp_file = Path.join([cache_dir(release_metadata), @stamp_cached])
+    stamp_file = Path.join([cache_path(release_metadata), @stamp_cached])
     Cache.exists?(cache_pid, stamp_file)
   end
 
-  def cache_dir(%__MODULE__{prn: release_prn}) do
-    Path.join([@cache_dir, release_prn])
+  def cache_path(%__MODULE__{prn: release_prn}) do
+    Path.join([@cache_path, release_prn])
   end
 
   def installed?(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
-    stamp_file = Path.join([cache_dir(release_metadata), @stamp_installed])
+    stamp_file = Path.join([cache_path(release_metadata), @stamp_installed])
     Cache.exists?(cache_pid, stamp_file)
   end
 
   def stamp_cached(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
-    stamp_file = Path.join([cache_dir(release_metadata), @stamp_cached])
+    stamp_file = Path.join([cache_path(release_metadata), @stamp_cached])
     Cache.write(cache_pid, stamp_file, stamp_utc_now())
   end
 
   def stamp_installed(cache_pid \\ Cache, %__MODULE__{} = release_metadata) do
-    stamp_file = Path.join([cache_dir(release_metadata), @stamp_installed])
+    stamp_file = Path.join([cache_path(release_metadata), @stamp_installed])
     Cache.write(cache_pid, stamp_file, stamp_utc_now())
   end
 

--- a/lib/peridiod/release/server.ex
+++ b/lib/peridiod/release/server.ex
@@ -442,6 +442,13 @@ defmodule Peridiod.Release.Server do
     {:no_update, state}
   end
 
+  defp update_response({:ok, %{status: status_code, body: body}}, state) do
+    Logger.debug("Release Manager: Non 200 response from server")
+    Logger.debug("Release Manager: Status code: #{inspect status_code}")
+    Logger.debug("Release Manager: Response: #{inspect body}")
+    {:no_update, state}
+  end
+
   defp update_response({:error, %{reason: reason}}, state) do
     Logger.error("Release Manager: error checking for update #{inspect(reason)}")
     {:no_update, state}

--- a/lib/peridiod/release/server.ex
+++ b/lib/peridiod/release/server.ex
@@ -132,10 +132,7 @@ defmodule Peridiod.Release.Server do
   def handle_continue(true, state) do
     Logger.debug("Release Polling Enabled")
 
-    {_resp, state} =
-      state
-      |> update_check()
-      |> update_response(state)
+    send(self(), :check_for_update)
 
     progress_message_timer =
       Process.send_after(self(), :send_progress_message, state.progress_message_interval)
@@ -444,8 +441,8 @@ defmodule Peridiod.Release.Server do
 
   defp update_response({:ok, %{status: status_code, body: body}}, state) do
     Logger.debug("Release Manager: Non 200 response from server")
-    Logger.debug("Release Manager: Status code: #{inspect status_code}")
-    Logger.debug("Release Manager: Response: #{inspect body}")
+    Logger.debug("Release Manager: Status code: #{inspect(status_code)}")
+    Logger.debug("Release Manager: Response: #{inspect(body)}")
     {:no_update, state}
   end
 
@@ -507,6 +504,7 @@ defmodule Peridiod.Release.Server do
          _callback,
          %{installing_release: {release_metadata, _, _}} = state
        ) do
+    IO.inspect("Error, release is currently being installed")
     {{:error, {:installing_release, release_metadata}}, state}
   end
 

--- a/test/peridiod/binary/installer_test.exs
+++ b/test/peridiod/binary/installer_test.exs
@@ -35,6 +35,29 @@ defmodule Peridiod.Binary.InstallerTest do
     end
   end
 
+  describe "install_downloader" do
+    setup :start_cache
+    setup :start_kv
+    setup :setup_cache
+
+    test "cache", %{binary_metadata: binary_metadata, opts: opts} do
+      spawn_installer(binary_metadata, opts)
+      prn = binary_metadata.prn
+      assert_receive {Installer, ^prn, :complete}
+    end
+  end
+
+  def setup_cache(context) do
+    application_config = Application.get_all_env(:peridiod)
+    config = struct(Peridiod.Config, application_config) |> Peridiod.Config.new()
+    binary_metadata = TestFixtures.binary_manifest_cache() |> Binary.metadata_from_manifest()
+    opts = %{callback: self(), config: config, cache_pid: context.cache_pid}
+
+    context
+    |> Map.put(:binary_metadata, binary_metadata)
+    |> Map.put(:opts, opts)
+  end
+
   def setup_fwup(context) do
     application_config = Application.get_all_env(:peridiod)
     config = struct(Peridiod.Config, application_config) |> Peridiod.Config.new()

--- a/test/peridiod/binary_test.exs
+++ b/test/peridiod/binary_test.exs
@@ -73,7 +73,7 @@ defmodule Peridiod.BinaryTest do
       signature_file =
         Path.join([
           cache_dir,
-          Binary.cache_dir({binary_metadata.prn, binary_metadata.custom_metadata_hash}),
+          Binary.cache_path({binary_metadata.prn, binary_metadata.custom_metadata_hash}),
           "manifest.sig"
         ])
 
@@ -98,7 +98,7 @@ defmodule Peridiod.BinaryTest do
       stamp_installed_file =
         Path.join([
           cache_dir,
-          Binary.cache_dir({binary_metadata.prn, binary_metadata.custom_metadata_hash}),
+          Binary.cache_path({binary_metadata.prn, binary_metadata.custom_metadata_hash}),
           ".stamp_installed"
         ])
 

--- a/test/peridiod/cache_test.exs
+++ b/test/peridiod/cache_test.exs
@@ -88,4 +88,12 @@ defmodule Peridiod.CacheTest do
     :ok = Cache.ln_s(cache_pid, file, link)
     assert {:ok, ^content} = File.read(Path.join([cache_dir, link]))
   end
+
+  test "rm", %{cache_pid: cache_pid, test: name} do
+    file = to_string(name)
+    content = to_string(name)
+    :ok = Cache.write(cache_pid, file, content)
+    Cache.rm(cache_pid, file)
+    assert {:error, :enoent} = Cache.read(cache_pid, file)
+  end
 end

--- a/test/support/test_fixtures.ex
+++ b/test/support/test_fixtures.ex
@@ -55,7 +55,27 @@ defmodule Peridiod.TestFixtures do
     "url" => "http://localhost:4001/1M.bin"
   }
 
-  @trusted_release_binary_fwup %{
+  @custom_metadata_fwup %{
+    "peridiod" => %{
+      "installer" => "fwup",
+      "installer_opts" => %{
+        "devpath" => "test/workspace",
+        "extra_args" => ["--unsafe"],
+        "env" => %{}
+      },
+      "reboot_required" => true
+    }
+  }
+
+  @custom_metadata_cache %{
+    "peridiod" => %{
+      "installer" => "cache",
+      "installer_opts" => %{},
+      "reboot_required" => false
+    }
+  }
+
+  @trusted_release_binary %{
     "artifact" => %{
       "name" => "fwup.fw",
       "prn" =>
@@ -68,17 +88,7 @@ defmodule Peridiod.TestFixtures do
     },
     "binary_prn" =>
       "prn:1:92d0a3ed-9058-4632-ae29-f420078c4507:binary:3018924c-f367-4870-9c17-e25ec68c9494",
-    "custom_metadata" => %{
-      "peridiod" => %{
-        "installer" => "fwup",
-        "installer_opts" => %{
-          "devpath" => "test/workspace",
-          "extra_args" => ["--unsafe"],
-          "env" => %{}
-        },
-        "reboot_required" => true
-      }
-    },
+    "custom_metadata" => @custom_metadata_fwup,
     "hash" => "8bb7566846ae03b99e55b72d022d0f899404af8a22a335b4be8789cb997f0ea2",
     "signatures" => [
       %{
@@ -157,7 +167,14 @@ defmodule Peridiod.TestFixtures do
   def untrusted_signing_key, do: SigningKey.new(:ed25519, untrusted_key_pem()) |> elem(1)
   def untrusted_release_binary, do: @untrusted_release_binary
   def binary_fixture_path(), do: Path.expand("../fixtures/binaries", __DIR__)
-  def binary_manifest_fwup(), do: @trusted_release_binary_fwup
+
+  def binary_manifest_fwup(),
+    do: @trusted_release_binary |> Map.put("custom_metadata", @custom_metadata_fwup)
+
+  def binary_manifest_cache(),
+    do: @trusted_release_binary |> Map.put("custom_metadata", @custom_metadata_cache)
+
+  def custom_metadata_cache(), do: @custom_metadata_cache
 
   def release_manifest(install_dir) do
     manifest =


### PR DESCRIPTION
This is a middle ground until we introduce relational job control in the release server. Allow installs that occur from a download stream to be either streamed directly to the installer process or downloaded into the cache directory before executing the install program.