### PR TITLE
fix duplicate cloud update check

### DIFF
--- a/lib/peridiod/cloud/update.ex
+++ b/lib/peridiod/cloud/update.ex
@@ -32,9 +32,7 @@ defmodule Peridiod.Cloud.Update do
 
     send(self(), :check_for_update)
 
-    update_timer = Process.send_after(self(), :check_for_update, state.poll_interval)
-
-    {:noreply, %{state | update_timer: update_timer}}
+    {:noreply, state}
   end
 
   def handle_continue(false, state) do


### PR DESCRIPTION
The call to schedule the "next check" (`Process.send_after(self(), :check_for_update, state.poll_interval)`) was happening in two places when it only should be in one.

This removes ones of them, which results in the desired behavior, which is the check only happening once per-interval.