### PR TITLE
ensure offline reconnect uses backoff

### DIFF
--- a/lib/peridiod/cloud.ex
+++ b/lib/peridiod/cloud.ex
@@ -138,7 +138,15 @@ defmodule Peridiod.Cloud do
       |> :inet_res.lookup(:in, :a, timeout: 1000)
       |> Enum.map(&Peridio.NetMon.IP.ip_to_string/1)
 
-    %{state | device_api_ip_cache: addresses}
+    case addresses do
+      [] ->
+        Logger.debug("[Cloud] DNS lookup returned no addresses, keeping existing cache")
+        state
+
+      _ ->
+        Logger.debug("[Cloud] DNS lookup returned #{length(addresses)} addresses")
+        %{state | device_api_ip_cache: addresses}
+    end
   end
 
   defp do_update_client_headers(client, headers) do


### PR DESCRIPTION
This fixes a specific loss-of-network failure scenario, which is DNS lookup fails, so it switches to using `:ip` mode, which then also fails, so it switches back to `:host`, which fails, so it switches back, etc.

In this looping process, nothing "throttles" the back-and-forth switching, so we can get a spam of log messages and flapping until one of the two resolves successfully.

This PR switches the re-connection attempts in each path to use Slipstream's `reconnect/1` [which uses backoff](https://hexdocs.pm/slipstream/Slipstream.html#reconnect/1), while `connect/2` or `connect!/2` do not.