### PR TITLE
[SOC2] Sanitize sensitive data from peridiod log output

### DIFF
--- a/.claude/linear.json
+++ b/.claude/linear.json
@@ -1,0 +1,3 @@
+{
+  "teamId": "284927bc-32ed-41df-a444-c0f1a594cebf"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`peridiod` is an Elixir-based reference implementation of a Peridio Agent for Embedded Linux. It's a device management daemon handling firmware/bundle updates, binary installation, and remote access tunnels for embedded systems.
+
+## Commands
+
+```bash
+# Install deps and compile
+make compile
+# or: mix deps.get && mix compile
+
+# Run tests
+mix test
+
+# Run a single test file
+mix test test/peridiod/plan_test.exs
+
+# Run a single test by line number
+mix test test/peridiod/plan_test.exs:42
+
+# Build a release binary
+make release
+# or: mix release --overwrite
+
+# Format code
+mix format
+```
+
+## Architecture
+
+### Supervision Tree
+
+```
+Peridiod.Application
+└── Supervisor (one_for_one)
+    ├── Cache               - File cache with Ed25519/SHA256 signing
+    ├── Cloud.Supervisor
+    │   ├── Cloud.Socket    - WebSocket to Peridio cloud (via Slipstream)
+    │   ├── Cloud.Update    - Polls for available updates
+    │   ├── Cloud.Tunnel    - Remote access tunnel (RAT) management
+    │   └── Cloud.NetworkMonitor - Watches network interface changes
+    ├── Bundle.Server       - Orchestrates bundle installation
+    ├── Binary.Installer.Supervisor
+    ├── Binary.Downloader.Supervisor
+    ├── Plan.Server         - Executes installation plans phase by phase
+    └── Plan.Step.Supervisor
+```
+
+### Update Flow
+
+1. `Cloud.Socket` receives update notification from Peridio cloud over WebSocket
+2. `Bundle.Server` receives the bundle/distribution, filters already-installed binaries
+3. `Plan` module builds an installation plan with four phases:
+   - **on_init**: Cache metadata, mark system state as in-progress
+   - **run**: Parallel/sequential steps — download, install binaries, enable Avocado extensions
+   - **on_finish**: Stamp installed, advance system state, reboot if required
+   - **on_error**: Reset progress state
+4. `Plan.Server` executes the plan step by step, dispatching to `Plan.Step.Supervisor`
+
+### Key Modules
+
+| Module | Purpose |
+|--------|---------|
+| `Peridiod.Config` | Reads `peridio-config.json` (or `$PERIDIO_CONFIG_FILE`). Supports `file`, `pkcs11`, `uboot-env`, `env` key pair sources |
+| `Peridiod.Cache` | Content-addressed file store; signs/verifies every file with Ed25519 |
+| `Peridiod.Plan` | Pure function — given a `Bundle`, returns a `%Plan{}` with ordered step lists |
+| `Peridiod.Plan.Server` | GenServer that drives plan execution through phases |
+| `Peridiod.Bundle.Server` | GenServer managing the overall bundle install lifecycle |
+| `Peridiod.Binary.Installer` | Dispatcher; selects installer module (`fwup`, `avocado-os`, `avocado-ext`, `deb`) based on `custom_metadata["peridiod"]["installer"]` |
+| `Peridiod.Cloud` | Manages Peridio SDK client, TLS, and DNS caching |
+| `Peridiod.Distribution` | Represents an update payload from cloud (legacy path via distributions) |
+
+### Installer Types
+
+Binary installers are selected via `custom_metadata["peridiod"]["installer"]`:
+- `fwup` — streams firmware to a block device via fwup
+- `avocado-os` — Avocado OS image install
+- `avocado-ext` — Avocado extension; requires a subsequent `AvocadoExtensionEnable` step
+- `deb` — Debian package
+
+Avocado components have special ordering in `Plan`: extensions install first → enable step → OS install (or refresh if no OS update).
+
+### Configuration
+
+Config is loaded from `peridio-config.json` (default: `$XDG_CONFIG_HOME/peridio/peridio-config.json` or `~/.config/peridio/peridio-config.json`). Override with `$PERIDIO_CONFIG_FILE`.
+
+Key config fields: `device_api.url`, `fwup.devpath`, `fwup.public_keys`, `node.key_pair_source`, `trusted_signing_keys`, `targets`, `remote_access_tunnels`.
+
+### External Dependencies (GitHub-pinned)
+
+- `peridio_sdk` (peridio/peridio-elixir) — Device API client
+- `peridiod_persistence` (peridio/peridiod-persistence) — KV store abstraction (in-memory for tests, file-backed in prod)
+- `peridio_rat` (peridio/peridio-rat) — WireGuard-based remote access tunnels
+- `peridio_net_mon` (peridio/peridio-net-mon) — Network interface monitoring
+
+### Test Setup
+
+Tests use `--no-start` (configured in `mix.exs` aliases). Key test config (`config/test.exs`):
+- Socket disabled
+- In-memory KV backend (`PeridiodPersistence.KVBackend.InMemory`)
+- Test workspace at `test/workspace/cache`
+- Test support files in `test/support/`

--- a/lib/peridiod/binary/chunk_downloader.ex
+++ b/lib/peridiod/binary/chunk_downloader.ex
@@ -14,6 +14,8 @@ defmodule Peridiod.Binary.ChunkDownloader do
     Downloader.TimeoutCalculation
   }
 
+  alias Peridiod.LogSanitizer
+
   require Logger
 
   defstruct id: nil,
@@ -422,7 +424,7 @@ defmodule Peridiod.Binary.ChunkDownloader do
     # Log detailed error information for this chunk
     Logger.error(
       "[Chunk Downloader #{state.id}_#{chunk_number}] Fatal HTTP error #{status} for chunk #{chunk_number} " <>
-        "(range #{range_start}-#{range_end}). URL: #{URI.to_string(uri)}"
+        "(range #{range_start}-#{range_end}). URL: #{LogSanitizer.sanitize_uri(uri)}"
     )
 
     # Send fatal error with URL for logging, then mark for clean shutdown
@@ -447,7 +449,7 @@ defmodule Peridiod.Binary.ChunkDownloader do
     location = fetch_location(headers)
 
     Logger.debug(
-      "[Chunk Downloader #{state.id}_#{state.chunk_number}] Redirecting to #{location}"
+      "[Chunk Downloader #{state.id}_#{state.chunk_number}] Redirecting to #{LogSanitizer.sanitize_uri(location)}"
     )
 
     state = reset(state)
@@ -564,7 +566,7 @@ defmodule Peridiod.Binary.ChunkDownloader do
     current_position = state.range_start + state.downloaded_length
 
     Logger.info(
-      "[Chunk Downloader #{state.id}_#{state.chunk_number}] CHUNK download attempt #{state.retry_number + 1} #{uri} (range #{current_position}-#{state.range_end})"
+      "[Chunk Downloader #{state.id}_#{state.chunk_number}] CHUNK download attempt #{state.retry_number + 1} #{LogSanitizer.sanitize_uri(uri)} (range #{current_position}-#{state.range_end})"
     )
 
     with {:ok, conn} <- Mint.HTTP.connect(String.to_existing_atom(scheme), host, port),

--- a/lib/peridiod/binary/downloader.ex
+++ b/lib/peridiod/binary/downloader.ex
@@ -345,7 +345,10 @@ defmodule Peridiod.Binary.Downloader do
       )
       when status >= 300 and status < 400 do
     location = fetch_location(headers)
-    Logger.debug("[Stream Downloader #{state.id}] Redirecting to #{LogSanitizer.sanitize_uri(location)}")
+
+    Logger.debug(
+      "[Stream Downloader #{state.id}] Redirecting to #{LogSanitizer.sanitize_uri(location)}"
+    )
 
     state = reset(state)
 

--- a/lib/peridiod/binary/downloader.ex
+++ b/lib/peridiod/binary/downloader.ex
@@ -23,6 +23,8 @@ defmodule Peridiod.Binary.Downloader do
     Downloader.TimeoutCalculation
   }
 
+  alias Peridiod.LogSanitizer
+
   require Logger
 
   defstruct id: nil,
@@ -343,7 +345,7 @@ defmodule Peridiod.Binary.Downloader do
       )
       when status >= 300 and status < 400 do
     location = fetch_location(headers)
-    Logger.debug("[Stream Downloader #{state.id}] Redirecting to #{location}")
+    Logger.debug("[Stream Downloader #{state.id}] Redirecting to #{LogSanitizer.sanitize_uri(location)}")
 
     state = reset(state)
 
@@ -433,7 +435,7 @@ defmodule Peridiod.Binary.Downloader do
       |> add_user_agent_header(state)
 
     Logger.info(
-      "[Stream Downloader #{state.id}] #{if(state.downloaded_length > 0, do: "RESUME", else: "INIT")} download attempt #{state.retry_number} #{uri}"
+      "[Stream Downloader #{state.id}] #{if(state.downloaded_length > 0, do: "RESUME", else: "INIT")} download attempt #{state.retry_number} #{LogSanitizer.sanitize_uri(uri)}"
     )
 
     # mint doesn't accept the query as the http body, so it must be encoded

--- a/lib/peridiod/cloud/socket.ex
+++ b/lib/peridiod/cloud/socket.ex
@@ -2,7 +2,7 @@ defmodule Peridiod.Cloud.Socket do
   use Slipstream
   require Logger
 
-  alias Peridiod.{Client, Distribution, RemoteConsole, Utils, Cloud}
+  alias Peridiod.{Client, Distribution, LogSanitizer, RemoteConsole, Utils, Cloud}
   alias Peridiod.Binary.Installer.Fwup
   alias PeridiodPersistence.KV
 
@@ -216,7 +216,7 @@ defmodule Peridiod.Cloud.Socket do
 
       error ->
         Logger.error(
-          "[Cloud Socket] Error parsing update data: #{inspect(update)} error: #{inspect(error)}"
+          "[Cloud Socket] Error parsing update data: #{inspect(LogSanitizer.sanitize_update(update))} error: #{inspect(error)}"
         )
 
         {:ok, socket}
@@ -226,11 +226,11 @@ defmodule Peridiod.Cloud.Socket do
   def handle_message(
         @device_topic,
         "tunnel_request",
-        %{"tunnel_prn" => tunnel_prn} = payload,
+        %{"tunnel_prn" => tunnel_prn},
         %{assigns: %{remote_access_tunnels: %{enabled: false}}} = socket
       ) do
     Logger.warning(
-      "[Cloud Socket] Remote Access Tunnel requested but not enabled on the device: #{inspect(payload)}"
+      "[Cloud Socket] Remote Access Tunnel requested but not enabled on the device: tunnel_prn=#{LogSanitizer.sanitize_prn(tunnel_prn)}"
     )
 
     Cloud.Tunnel.close(tunnel_prn, "feature_not_enabled")
@@ -405,7 +405,7 @@ defmodule Peridiod.Cloud.Socket do
   end
 
   def handle_info(msg, socket) do
-    Logger.warning("[Cloud Socket] Unhandled handle_info: #{inspect(msg)}")
+    Logger.warning("[Cloud Socket] Unhandled handle_info: #{inspect(msg, limit: 50)}")
     {:noreply, socket}
   end
 
@@ -431,7 +431,7 @@ defmodule Peridiod.Cloud.Socket do
 
       addresses ->
         address = Enum.random(addresses)
-        Logger.info("[Cloud Socket] Attempting reconnect with IP #{address}")
+        Logger.info("[Cloud Socket] Attempting reconnect with IP #{LogSanitizer.sanitize_ip(address)}")
 
         updated_socket =
           socket
@@ -479,7 +479,7 @@ defmodule Peridiod.Cloud.Socket do
 
       error ->
         Logger.error(
-          "[Cloud Socket] Error parsing update data: #{inspect(update)} error: #{inspect(error)}"
+          "[Cloud Socket] Error parsing update data: #{inspect(LogSanitizer.sanitize_update(update))} error: #{inspect(error)}"
         )
 
         :noop

--- a/lib/peridiod/cloud/socket.ex
+++ b/lib/peridiod/cloud/socket.ex
@@ -431,7 +431,10 @@ defmodule Peridiod.Cloud.Socket do
 
       addresses ->
         address = Enum.random(addresses)
-        Logger.info("[Cloud Socket] Attempting reconnect with IP #{LogSanitizer.sanitize_ip(address)}")
+
+        Logger.info(
+          "[Cloud Socket] Attempting reconnect with IP #{LogSanitizer.sanitize_ip(address)}"
+        )
 
         updated_socket =
           socket

--- a/lib/peridiod/cloud/tunnel.ex
+++ b/lib/peridiod/cloud/tunnel.ex
@@ -4,7 +4,7 @@ defmodule Peridiod.Cloud.Tunnel do
   # Cloud -> Device: Response interface / peer information
   require Logger
 
-  alias Peridiod.Cloud
+  alias Peridiod.{Cloud, LogSanitizer}
   alias Peridio.RAT
   alias Peridio.RAT.{Network, WireGuard}
 
@@ -83,7 +83,7 @@ defmodule Peridiod.Cloud.Tunnel do
             # Server lists tunnel as open, but the config is missing locally. No way to recover, close the tunnel
             nil ->
               Logger.debug(
-                "[Remote Access Tunnels] Closing open tunnel missing local config: #{inspect(tunnel_data["prn"])}"
+                "[Remote Access Tunnels] Closing open tunnel missing local config: #{LogSanitizer.sanitize_prn(tunnel_data["prn"])}"
               )
 
               close_request(client, tunnel_data["prn"], "device_tunnel_abnormal_down")

--- a/lib/peridiod/cloud/update.ex
+++ b/lib/peridiod/cloud/update.ex
@@ -3,7 +3,7 @@ defmodule Peridiod.Cloud.Update do
 
   require Logger
 
-  alias Peridiod.{Cloud, Bundle, BundleOverride, Release}
+  alias Peridiod.{Cloud, Bundle, BundleOverride, LogSanitizer, Release}
 
   @update_poll_interval 30 * 60 * 1000
 
@@ -127,7 +127,7 @@ defmodule Peridiod.Cloud.Update do
   defp update_response({_, %{status: status_code, body: body}}) do
     Logger.info("[Cloud Server] Non 200 response from server")
     Logger.info("[Cloud Server] Status code: #{inspect(status_code)}")
-    Logger.info("[Cloud Server] Response: #{inspect(body)}")
+    Logger.info("[Cloud Server] Response: #{inspect(LogSanitizer.sanitize_update(body))}")
     {:error, body}
   end
 
@@ -152,7 +152,7 @@ defmodule Peridiod.Cloud.Update do
 
       addresses ->
         address = Enum.random(addresses)
-        Logger.warning("[Cloud Server] Using IP Address #{address}")
+        Logger.warning("[Cloud Server] Using IP Address #{LogSanitizer.sanitize_ip(address)}")
 
         client =
           Cloud.get_client()

--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -2,7 +2,7 @@ defmodule Peridiod.Config do
   use Peridiod.Log
 
   alias PeridiodPersistence.KV
-  alias Peridiod.{Cloud, Cache, SigningKey, Plan}
+  alias Peridiod.{Cloud, Cache, LogSanitizer, SigningKey, Plan}
   alias __MODULE__
 
   require Logger
@@ -389,7 +389,7 @@ defmodule Peridiod.Config do
           [signing_key | signing_keys]
 
         error ->
-          Logger.error("[Config] Error loading signing key\n#{key}\nError: #{inspect(error)}")
+          Logger.error("[Config] Error loading signing key #{LogSanitizer.sanitize_key(key)} Error: #{inspect(error)}")
           signing_keys
       end
     end)

--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -389,7 +389,10 @@ defmodule Peridiod.Config do
           [signing_key | signing_keys]
 
         error ->
-          Logger.error("[Config] Error loading signing key #{LogSanitizer.sanitize_key(key)} Error: #{inspect(error)}")
+          Logger.error(
+            "[Config] Error loading signing key #{LogSanitizer.sanitize_key(key)} Error: #{inspect(error)}"
+          )
+
           signing_keys
       end
     end)

--- a/lib/peridiod/crypto.ex
+++ b/lib/peridiod/crypto.ex
@@ -39,8 +39,12 @@ defmodule Peridiod.Crypto do
         _algorithm,
         %{engine: _engine, key_id: _key_id, algorithm: _crypto_algorithm} = engine_key
       ) do
-    Logger.error("Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}")
-    raise ArgumentError, "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
+    Logger.error(
+      "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
+    )
+
+    raise ArgumentError,
+          "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
   end
 
   def sign(hash, algorithm, private_key) do
@@ -64,8 +68,12 @@ defmodule Peridiod.Crypto do
         _signature,
         %{engine: _engine, key_id: _key_id, algorithm: _crypto_algorithm} = engine_key
       ) do
-    Logger.error("Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}")
-    raise ArgumentError, "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
+    Logger.error(
+      "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
+    )
+
+    raise ArgumentError,
+          "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
   end
 
   def verified?(hash, algorithm, signature, public_key) do

--- a/lib/peridiod/crypto.ex
+++ b/lib/peridiod/crypto.ex
@@ -1,4 +1,6 @@
 defmodule Peridiod.Crypto do
+  alias Peridiod.LogSanitizer
+
   require Logger
 
   @stream_chunk_size 4096
@@ -37,8 +39,8 @@ defmodule Peridiod.Crypto do
         _algorithm,
         %{engine: _engine, key_id: _key_id, algorithm: _crypto_algorithm} = engine_key
       ) do
-    Logger.error("Unrecognized key format: #{inspect(engine_key)}")
-    raise ArgumentError, "Unrecognized key format: #{inspect(engine_key)}"
+    Logger.error("Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}")
+    raise ArgumentError, "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
   end
 
   def sign(hash, algorithm, private_key) do
@@ -62,8 +64,8 @@ defmodule Peridiod.Crypto do
         _signature,
         %{engine: _engine, key_id: _key_id, algorithm: _crypto_algorithm} = engine_key
       ) do
-    Logger.error("Unrecognized key format: #{inspect(engine_key)}")
-    raise ArgumentError, "Unrecognized key format: #{inspect(engine_key)}"
+    Logger.error("Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}")
+    raise ArgumentError, "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
   end
 
   def verified?(hash, algorithm, signature, public_key) do

--- a/lib/peridiod/crypto.ex
+++ b/lib/peridiod/crypto.ex
@@ -39,12 +39,9 @@ defmodule Peridiod.Crypto do
         _algorithm,
         %{engine: _engine, key_id: _key_id, algorithm: _crypto_algorithm} = engine_key
       ) do
-    Logger.error(
-      "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
-    )
-
-    raise ArgumentError,
-          "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
+    sanitized = inspect(LogSanitizer.sanitize_engine_key(engine_key))
+    Logger.error("Unrecognized key format: #{sanitized}")
+    raise ArgumentError, "Unrecognized key format: #{sanitized}"
   end
 
   def sign(hash, algorithm, private_key) do
@@ -68,12 +65,9 @@ defmodule Peridiod.Crypto do
         _signature,
         %{engine: _engine, key_id: _key_id, algorithm: _crypto_algorithm} = engine_key
       ) do
-    Logger.error(
-      "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
-    )
-
-    raise ArgumentError,
-          "Unrecognized key format: #{inspect(LogSanitizer.sanitize_engine_key(engine_key))}"
+    sanitized = inspect(LogSanitizer.sanitize_engine_key(engine_key))
+    Logger.error("Unrecognized key format: #{sanitized}")
+    raise ArgumentError, "Unrecognized key format: #{sanitized}"
   end
 
   def verified?(hash, algorithm, signature, public_key) do

--- a/lib/peridiod/distribution/server.ex
+++ b/lib/peridiod/distribution/server.ex
@@ -555,7 +555,9 @@ defmodule Peridiod.Distribution.Server do
     firmware_uuid = distribution.firmware_meta.uuid
     firmware_url = distribution.firmware_url
 
-    Logger.info("[Distributions] Downloading and streaming firmware to fwup: #{LogSanitizer.sanitize_uri(firmware_url)}")
+    Logger.info(
+      "[Distributions] Downloading and streaming firmware to fwup: #{LogSanitizer.sanitize_uri(firmware_url)}"
+    )
 
     {:ok, download} = start_downloader(firmware_uuid, firmware_url, handler_fun)
 
@@ -564,7 +566,9 @@ defmodule Peridiod.Distribution.Server do
         fwup_env: state.fwup_config.fwup_env
       )
 
-    Logger.info("[Distributions] Downloading firmware: #{LogSanitizer.sanitize_uri(firmware_url)}")
+    Logger.info(
+      "[Distributions] Downloading firmware: #{LogSanitizer.sanitize_uri(firmware_url)}"
+    )
 
     %State{
       state

--- a/lib/peridiod/distribution/server.ex
+++ b/lib/peridiod/distribution/server.ex
@@ -9,7 +9,7 @@ defmodule Peridiod.Distribution.Server do
   """
   use GenServer
 
-  alias Peridiod.{Client, Distribution, Cache}
+  alias Peridiod.{Client, Distribution, Cache, LogSanitizer}
 
   alias Peridiod.Binary.{
     Downloader,
@@ -239,7 +239,7 @@ defmodule Peridiod.Distribution.Server do
   def handle_info({:download, {:fatal_http_error, status, uri}}, state) do
     Logger.error(
       "[Distributions] Fatal HTTP error #{status} downloading firmware. " <>
-        "URL: #{URI.to_string(uri)} - Update aborted, ready for new update."
+        "URL: #{LogSanitizer.sanitize_uri(uri)} - Update aborted, ready for new update."
     )
 
     {:noreply, reset_update_state(state)}
@@ -458,7 +458,7 @@ defmodule Peridiod.Distribution.Server do
     state = %{state | status: {:updating, 0}, distribution: distribution}
 
     Logger.info(
-      "[Distributions] Downloading firmware to disk cache (with live FWUP stream): #{firmware_url}"
+      "[Distributions] Downloading firmware to disk cache (with live FWUP stream): #{LogSanitizer.sanitize_uri(firmware_url)}"
     )
 
     :ok = cleanup_download_cache(state.config.cache_pid, firmware_uuid)
@@ -555,7 +555,7 @@ defmodule Peridiod.Distribution.Server do
     firmware_uuid = distribution.firmware_meta.uuid
     firmware_url = distribution.firmware_url
 
-    Logger.info("[Distributions] Downloading and streaming firmware to fwup: #{firmware_url}")
+    Logger.info("[Distributions] Downloading and streaming firmware to fwup: #{LogSanitizer.sanitize_uri(firmware_url)}")
 
     {:ok, download} = start_downloader(firmware_uuid, firmware_url, handler_fun)
 
@@ -564,7 +564,7 @@ defmodule Peridiod.Distribution.Server do
         fwup_env: state.fwup_config.fwup_env
       )
 
-    Logger.info("[Distributions] Downloading firmware: #{firmware_url}")
+    Logger.info("[Distributions] Downloading firmware: #{LogSanitizer.sanitize_uri(firmware_url)}")
 
     %State{
       state
@@ -768,7 +768,7 @@ defmodule Peridiod.Distribution.Server do
 
       {:parallel, total_size, final_rel_path} ->
         Logger.info(
-          "[Distributions] Starting parallel file download: #{firmware_url} (#{total_size} bytes) with #{state.config.distributions_download_parallel_count} parallel connections, #{state.config.distributions_download_parallel_chunk_bytes} bytes per chunk"
+          "[Distributions] Starting parallel file download: #{LogSanitizer.sanitize_uri(firmware_url)} (#{total_size} bytes) with #{state.config.distributions_download_parallel_count} parallel connections, #{state.config.distributions_download_parallel_chunk_bytes} bytes per chunk"
         )
 
         {:ok, download} =

--- a/lib/peridiod/log_sanitizer.ex
+++ b/lib/peridiod/log_sanitizer.ex
@@ -15,7 +15,7 @@ defmodule Peridiod.LogSanitizer do
   def sanitize_uri(%URI{query: nil, fragment: nil} = uri), do: URI.to_string(uri)
 
   def sanitize_uri(%URI{} = uri) do
-    %URI{uri | query: (if uri.query, do: "[FILTERED]"), fragment: nil}
+    %URI{uri | query: if(uri.query, do: "[FILTERED]"), fragment: nil}
     |> URI.to_string()
   end
 

--- a/lib/peridiod/log_sanitizer.ex
+++ b/lib/peridiod/log_sanitizer.ex
@@ -1,0 +1,86 @@
+defmodule Peridiod.LogSanitizer do
+  @moduledoc """
+  Sanitizes sensitive data before it is written to log output.
+
+  Use these functions at Logger call sites to strip auth tokens, key material,
+  and other confidential values while preserving enough context for debugging.
+  """
+
+  @doc """
+  Strips query params and fragment from a URI, replacing the query with `[FILTERED]`.
+
+  Firmware download URIs often contain pre-signed S3 tokens in query parameters.
+  The scheme/host/path are preserved for debugging.
+  """
+  def sanitize_uri(%URI{query: nil, fragment: nil} = uri), do: URI.to_string(uri)
+
+  def sanitize_uri(%URI{} = uri) do
+    %URI{uri | query: (if uri.query, do: "[FILTERED]"), fragment: nil}
+    |> URI.to_string()
+  end
+
+  def sanitize_uri(uri) when is_binary(uri) do
+    uri |> URI.parse() |> sanitize_uri()
+  end
+
+  def sanitize_uri(nil), do: "[nil]"
+
+  @doc """
+  Redacts key material entirely. No partial display — there is no debugging
+  value in showing part of a PEM key or other secret.
+  """
+  def sanitize_key(_key), do: "[FILTERED KEY]"
+
+  @doc """
+  Redacts the org UUID and resource UUID from a PRN while preserving its
+  structural type segments for debugging.
+
+  Example: `"prn:1:abc-123:device:xyz-456"` → `"prn:1:***:device:***"`
+  """
+  def sanitize_prn(prn) when is_binary(prn) do
+    case String.split(prn, ":") do
+      ["prn", version, _org_id, resource_type | _rest] ->
+        "prn:#{version}:***:#{resource_type}:***"
+
+      _ ->
+        "[FILTERED PRN]"
+    end
+  end
+
+  def sanitize_prn(nil), do: "[nil]"
+
+  @doc """
+  Partially redacts an IPv4 address, keeping the first two octets for
+  network-level debugging while masking the host portion.
+
+  Example: `"192.168.1.100"` → `"192.168.xxx.xxx"`
+  """
+  def sanitize_ip(address) when is_binary(address) do
+    case String.split(address, ".") do
+      [a, b, _, _] -> "#{a}.#{b}.xxx.xxx"
+      _ -> "[FILTERED IP]"
+    end
+  end
+
+  def sanitize_ip(nil), do: "[nil]"
+
+  @doc """
+  Sanitizes the `"firmware_url"` field in an update payload map.
+  Other keys are passed through unchanged.
+  """
+  def sanitize_update(%{"firmware_url" => url} = update) when is_binary(url) do
+    Map.put(update, "firmware_url", sanitize_uri(url))
+  end
+
+  def sanitize_update(update), do: update
+
+  @doc """
+  Redacts the `:key_id` from an engine key map while preserving `:engine`
+  and `:algorithm` for debugging PKCS#11 configuration issues.
+  """
+  def sanitize_engine_key(%{engine: engine, key_id: _key_id, algorithm: algorithm}) do
+    %{engine: engine, key_id: "[FILTERED]", algorithm: algorithm}
+  end
+
+  def sanitize_engine_key(key), do: key
+end

--- a/lib/peridiod/log_sanitizer.ex
+++ b/lib/peridiod/log_sanitizer.ex
@@ -56,8 +56,8 @@ defmodule Peridiod.LogSanitizer do
   Example: `"192.168.1.100"` → `"192.168.xxx.xxx"`
   """
   def sanitize_ip(address) when is_binary(address) do
-    case String.split(address, ".") do
-      [a, b, _, _] -> "#{a}.#{b}.xxx.xxx"
+    case :inet.parse_address(String.to_charlist(address)) do
+      {:ok, {a, b, _c, _d}} -> "#{a}.#{b}.xxx.xxx"
       _ -> "[FILTERED IP]"
     end
   end

--- a/lib/peridiod/log_sanitizer.ex
+++ b/lib/peridiod/log_sanitizer.ex
@@ -39,7 +39,7 @@ defmodule Peridiod.LogSanitizer do
   """
   def sanitize_prn(prn) when is_binary(prn) do
     case String.split(prn, ":") do
-      ["prn", version, _org_id, resource_type | _rest] ->
+      ["prn", version, _org_id, resource_type, _resource_id | _] ->
         "prn:#{version}:***:#{resource_type}:***"
 
       _ ->
@@ -68,18 +68,18 @@ defmodule Peridiod.LogSanitizer do
   Sanitizes the `"firmware_url"` field in an update payload map.
   Other keys are passed through unchanged.
   """
-  def sanitize_update(%{"firmware_url" => url} = update) when is_binary(url) do
+  def sanitize_update(%{"firmware_url" => url} = update) do
     Map.put(update, "firmware_url", sanitize_uri(url))
   end
 
   def sanitize_update(update), do: update
 
   @doc """
-  Redacts the `:key_id` from an engine key map while preserving `:engine`
-  and `:algorithm` for debugging PKCS#11 configuration issues.
+  Redacts the `:key_id` from an engine key map while preserving the rest of
+  the map for debugging PKCS#11 configuration issues.
   """
-  def sanitize_engine_key(%{engine: engine, key_id: _key_id, algorithm: algorithm}) do
-    %{engine: engine, key_id: "[FILTERED]", algorithm: algorithm}
+  def sanitize_engine_key(%{key_id: _} = key) do
+    Map.put(key, :key_id, "[FILTERED]")
   end
 
   def sanitize_engine_key(key), do: key

--- a/test/peridiod/log_sanitizer_test.exs
+++ b/test/peridiod/log_sanitizer_test.exs
@@ -104,6 +104,7 @@ defmodule Peridiod.LogSanitizerTest do
     test "handles non-IPv4 format" do
       assert LogSanitizer.sanitize_ip("not-an-ip") == "[FILTERED IP]"
       assert LogSanitizer.sanitize_ip("::1") == "[FILTERED IP]"
+      assert LogSanitizer.sanitize_ip("a.b.c.d") == "[FILTERED IP]"
     end
 
     test "handles nil" do

--- a/test/peridiod/log_sanitizer_test.exs
+++ b/test/peridiod/log_sanitizer_test.exs
@@ -78,6 +78,7 @@ defmodule Peridiod.LogSanitizerTest do
     test "handles invalid PRN format" do
       assert LogSanitizer.sanitize_prn("not-a-prn") == "[FILTERED PRN]"
       assert LogSanitizer.sanitize_prn("prn:1") == "[FILTERED PRN]"
+      assert LogSanitizer.sanitize_prn("prn:1:org:device") == "[FILTERED PRN]"
     end
 
     test "handles nil" do
@@ -127,10 +128,10 @@ defmodule Peridiod.LogSanitizerTest do
   end
 
   describe "sanitize_engine_key/1" do
-    test "redacts key_id, preserves engine and algorithm" do
-      key = %{engine: :pkcs11, key_id: "slot=0:label=device-key", algorithm: :ecdsa}
+    test "redacts key_id, preserves all other fields" do
+      key = %{engine: :pkcs11, key_id: "slot=0:label=device-key", algorithm: :ecdsa, extra: "context"}
       result = LogSanitizer.sanitize_engine_key(key)
-      assert result == %{engine: :pkcs11, key_id: "[FILTERED]", algorithm: :ecdsa}
+      assert result == %{engine: :pkcs11, key_id: "[FILTERED]", algorithm: :ecdsa, extra: "context"}
       refute inspect(result) =~ "device-key"
     end
 

--- a/test/peridiod/log_sanitizer_test.exs
+++ b/test/peridiod/log_sanitizer_test.exs
@@ -5,7 +5,11 @@ defmodule Peridiod.LogSanitizerTest do
 
   describe "sanitize_uri/1" do
     test "strips query params and fragment from URI struct" do
-      uri = URI.parse("https://s3.amazonaws.com/bucket/firmware.fw?X-Amz-Signature=abc123&X-Amz-Credential=key#frag")
+      uri =
+        URI.parse(
+          "https://s3.amazonaws.com/bucket/firmware.fw?X-Amz-Signature=abc123&X-Amz-Credential=key#frag"
+        )
+
       result = LogSanitizer.sanitize_uri(uri)
       assert result == "https://s3.amazonaws.com/bucket/firmware.fw?[FILTERED]"
       refute String.contains?(result, "abc123")
@@ -129,9 +133,22 @@ defmodule Peridiod.LogSanitizerTest do
 
   describe "sanitize_engine_key/1" do
     test "redacts key_id, preserves all other fields" do
-      key = %{engine: :pkcs11, key_id: "slot=0:label=device-key", algorithm: :ecdsa, extra: "context"}
+      key = %{
+        engine: :pkcs11,
+        key_id: "slot=0:label=device-key",
+        algorithm: :ecdsa,
+        extra: "context"
+      }
+
       result = LogSanitizer.sanitize_engine_key(key)
-      assert result == %{engine: :pkcs11, key_id: "[FILTERED]", algorithm: :ecdsa, extra: "context"}
+
+      assert result == %{
+               engine: :pkcs11,
+               key_id: "[FILTERED]",
+               algorithm: :ecdsa,
+               extra: "context"
+             }
+
       refute inspect(result) =~ "device-key"
     end
 

--- a/test/peridiod/log_sanitizer_test.exs
+++ b/test/peridiod/log_sanitizer_test.exs
@@ -1,0 +1,142 @@
+defmodule Peridiod.LogSanitizerTest do
+  use ExUnit.Case, async: true
+
+  alias Peridiod.LogSanitizer
+
+  describe "sanitize_uri/1" do
+    test "strips query params and fragment from URI struct" do
+      uri = URI.parse("https://s3.amazonaws.com/bucket/firmware.fw?X-Amz-Signature=abc123&X-Amz-Credential=key#frag")
+      result = LogSanitizer.sanitize_uri(uri)
+      assert result == "https://s3.amazonaws.com/bucket/firmware.fw?[FILTERED]"
+      refute String.contains?(result, "abc123")
+      refute String.contains?(result, "key")
+      refute String.contains?(result, "frag")
+    end
+
+    test "preserves scheme, host, port, and path" do
+      uri = URI.parse("https://example.com:8443/path/to/file?token=secret")
+      result = LogSanitizer.sanitize_uri(uri)
+      assert result == "https://example.com:8443/path/to/file?[FILTERED]"
+    end
+
+    test "leaves URIs without query params unchanged" do
+      uri = URI.parse("https://example.com/path/to/file")
+      result = LogSanitizer.sanitize_uri(uri)
+      assert result == "https://example.com/path/to/file"
+    end
+
+    test "strips fragment even when no query params" do
+      uri = URI.parse("https://example.com/path#section")
+      result = LogSanitizer.sanitize_uri(uri)
+      assert result == "https://example.com/path"
+    end
+
+    test "accepts binary URLs" do
+      result = LogSanitizer.sanitize_uri("https://example.com/fw?token=secret")
+      assert result == "https://example.com/fw?[FILTERED]"
+      refute String.contains?(result, "secret")
+    end
+
+    test "accepts binary URL without query" do
+      result = LogSanitizer.sanitize_uri("https://example.com/fw")
+      assert result == "https://example.com/fw"
+    end
+
+    test "handles nil" do
+      assert LogSanitizer.sanitize_uri(nil) == "[nil]"
+    end
+  end
+
+  describe "sanitize_key/1" do
+    test "redacts PEM key string" do
+      pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAK...\n-----END RSA PRIVATE KEY-----"
+      assert LogSanitizer.sanitize_key(pem) == "[FILTERED KEY]"
+    end
+
+    test "redacts any value" do
+      assert LogSanitizer.sanitize_key("anything") == "[FILTERED KEY]"
+      assert LogSanitizer.sanitize_key(nil) == "[FILTERED KEY]"
+      assert LogSanitizer.sanitize_key(12345) == "[FILTERED KEY]"
+    end
+  end
+
+  describe "sanitize_prn/1" do
+    test "redacts org UUID and resource UUID" do
+      prn = "prn:1:abc-123-org:device:xyz-456-resource"
+      result = LogSanitizer.sanitize_prn(prn)
+      assert result == "prn:1:***:device:***"
+      refute String.contains?(result, "abc-123-org")
+      refute String.contains?(result, "xyz-456-resource")
+    end
+
+    test "preserves PRN version and resource type" do
+      prn = "prn:2:some-org:bundle:some-bundle-id"
+      result = LogSanitizer.sanitize_prn(prn)
+      assert result == "prn:2:***:bundle:***"
+    end
+
+    test "handles invalid PRN format" do
+      assert LogSanitizer.sanitize_prn("not-a-prn") == "[FILTERED PRN]"
+      assert LogSanitizer.sanitize_prn("prn:1") == "[FILTERED PRN]"
+    end
+
+    test "handles nil" do
+      assert LogSanitizer.sanitize_prn(nil) == "[nil]"
+    end
+  end
+
+  describe "sanitize_ip/1" do
+    test "redacts last two octets of IPv4 address" do
+      result = LogSanitizer.sanitize_ip("192.168.1.100")
+      assert result == "192.168.xxx.xxx"
+    end
+
+    test "preserves first two octets" do
+      result = LogSanitizer.sanitize_ip("10.20.30.40")
+      assert result == "10.20.xxx.xxx"
+    end
+
+    test "handles non-IPv4 format" do
+      assert LogSanitizer.sanitize_ip("not-an-ip") == "[FILTERED IP]"
+      assert LogSanitizer.sanitize_ip("::1") == "[FILTERED IP]"
+    end
+
+    test "handles nil" do
+      assert LogSanitizer.sanitize_ip(nil) == "[nil]"
+    end
+  end
+
+  describe "sanitize_update/1" do
+    test "sanitizes firmware_url in update map" do
+      update = %{"firmware_url" => "https://s3.amazonaws.com/fw?token=secret", "other" => "value"}
+      result = LogSanitizer.sanitize_update(update)
+      assert result["firmware_url"] == "https://s3.amazonaws.com/fw?[FILTERED]"
+      assert result["other"] == "value"
+    end
+
+    test "passes through maps without firmware_url" do
+      update = %{"status" => "ok", "version" => "1.0"}
+      assert LogSanitizer.sanitize_update(update) == update
+    end
+
+    test "passes through non-map values" do
+      assert LogSanitizer.sanitize_update("string") == "string"
+      assert LogSanitizer.sanitize_update(nil) == nil
+      assert LogSanitizer.sanitize_update(42) == 42
+    end
+  end
+
+  describe "sanitize_engine_key/1" do
+    test "redacts key_id, preserves engine and algorithm" do
+      key = %{engine: :pkcs11, key_id: "slot=0:label=device-key", algorithm: :ecdsa}
+      result = LogSanitizer.sanitize_engine_key(key)
+      assert result == %{engine: :pkcs11, key_id: "[FILTERED]", algorithm: :ecdsa}
+      refute inspect(result) =~ "device-key"
+    end
+
+    test "passes through non-matching values" do
+      assert LogSanitizer.sanitize_engine_key(:unknown) == :unknown
+      assert LogSanitizer.sanitize_engine_key(%{other: "key"}) == %{other: "key"}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds \`Peridiod.LogSanitizer\` module with pure functions for redacting signed URIs (strips query params containing S3 auth tokens), key material, PRNs, IP addresses, update payloads, and PKCS#11 engine key IDs
- Applies sanitization at 18 log call sites across \`distribution/server.ex\`, \`binary/downloader.ex\`, \`binary/chunk_downloader.ex\`, \`cloud/socket.ex\`, \`cloud/update.ex\`, \`cloud/tunnel.ex\`, \`config.ex\`, and \`crypto.ex\`
- Adds 22 unit tests for all sanitizer functions
- Adds \`CLAUDE.md\` with project context for Claude Code (architecture, commands, module overview)
- Adds \`.claude/linear.json\` with team ID for Linear issue integration in Claude Code

Closes ENG-1709

## Test plan

- [ ] \`mix compile --warnings-as-errors\` passes with no warnings
- [ ] \`mix test\` passes (184 tests, 0 failures)
- [ ] \`mix test test/peridiod/log_sanitizer_test.exs\` all sanitizer tests pass
- [ ] Verify no raw query params appear in logs when downloading firmware (signed S3 URLs show \`?[FILTERED]\`)
- [ ] Verify PEM key material is not logged on signing key load errors