### PR TITLE
[SOC2] Encrypt cached firmware and binaries at rest

### DIFF
--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -109,6 +109,8 @@ defmodule Peridiod.Cache do
 
     case dek_result do
       {:ok, dek} ->
+        if dek != nil, do: cleanup_orphaned_plaintext(cache_dir)
+
         {:ok,
          %{
            path: cache_dir,
@@ -396,6 +398,7 @@ defmodule Peridiod.Cache do
 
           error ->
             File.rm(tmp_path)
+            File.rm(file_path)
             error
         end
 
@@ -403,6 +406,35 @@ defmodule Peridiod.Cache do
         File.rm(tmp_path)
         File.rm(file_path)
         error
+    end
+  end
+
+  # Remove plaintext temp files left behind by decrypt_to_tempfile calls that were
+  # interrupted before the caller could clean up. Called on startup when encryption
+  # is enabled so plaintext never persists across restarts.
+  defp cleanup_orphaned_plaintext(cache_dir) do
+    tmp_dir = Path.join(cache_dir, ".tmp")
+
+    case File.ls(tmp_dir) do
+      {:ok, entries} ->
+        Enum.each(entries, fn entry ->
+          path = Path.join(tmp_dir, entry)
+
+          case File.lstat(path) do
+            {:ok, %File.Stat{type: :regular}} ->
+              Logger.debug("[Cache] Removing leftover temp file: #{path}")
+              File.rm(path)
+
+            _ ->
+              :ok
+          end
+        end)
+
+      {:error, :enoent} ->
+        :ok
+
+      _ ->
+        :ok
     end
   end
 

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -1,7 +1,12 @@
 defmodule Peridiod.Cache do
   use GenServer
 
+  import Bitwise, only: [band: 2]
   import Peridiod.Crypto
+
+  alias Peridiod.Cache.Encryption
+
+  require Logger
 
   @hash_algorithm :sha256
   @stream_chunk_size 4096
@@ -54,6 +59,30 @@ defmodule Peridiod.Cache do
     GenServer.call(pid_or_name, {:abs_path, file})
   end
 
+  @doc """
+  Returns the decrypted content of a cache file as a temporary file on disk.
+
+  When encryption is enabled, decrypts the file to a temp path under
+  `cache_dir/.tmp/` and returns `{:ok, temp_path}`. When encryption is
+  disabled, returns `{:ok, original_path}` (no copy is made).
+
+  The caller is responsible for removing the temp file when done; use
+  `cleanup_tempfile/2` to do so safely.
+  """
+  def decrypt_to_tempfile(pid_or_name \\ __MODULE__, file) do
+    GenServer.call(pid_or_name, {:decrypt_to_tempfile, file})
+  end
+
+  @doc """
+  Removes a temporary file previously returned by `decrypt_to_tempfile/2`.
+
+  Only removes files that live under `cache_dir/.tmp/`; silently succeeds for
+  any other path (e.g., the original cache path returned when encryption is off).
+  """
+  def cleanup_tempfile(pid_or_name \\ __MODULE__, path) when is_binary(path) do
+    GenServer.call(pid_or_name, {:cleanup_tempfile, path})
+  end
+
   def rm(pid_or_name \\ __MODULE__, file) do
     GenServer.call(pid_or_name, {:rm, file})
   end
@@ -67,13 +96,31 @@ defmodule Peridiod.Cache do
     public_key = config.cache_public_key
     cache_dir = config.cache_dir
     hash_algorithm = Map.get(config, :cache_hash_algorithm, @hash_algorithm)
+    encryption_enabled = Map.get(config, :cache_encryption_enabled, true)
+
+    init_cache_dir(cache_dir)
+
+    dek =
+      if encryption_enabled do
+        case Encryption.load_or_create_dek(cache_dir, private_key, public_key) do
+          {:ok, dek} ->
+            dek
+
+          {:error, reason} ->
+            Logger.error("[Cache] Failed to load or create DEK: #{inspect(reason)}")
+            nil
+        end
+      else
+        nil
+      end
 
     {:ok,
      %{
        path: cache_dir,
        hash_algorithm: hash_algorithm,
        private_key: private_key,
-       public_key: public_key
+       public_key: public_key,
+       dek: dek
      }}
   end
 
@@ -99,7 +146,19 @@ defmodule Peridiod.Cache do
       with true <- File.exists?(file_path),
            {:ok, signature_hex} <- File.read(file_sig_path),
            {:ok, signature} <- Base.decode16(signature_hex, case: :mixed) do
-        do_read_stream(file_path, state.hash_algorithm, signature, state.public_key)
+        case state.dek do
+          nil ->
+            do_read_stream(file_path, state.hash_algorithm, signature, state.public_key)
+
+          dek ->
+            Encryption.decrypt_stream(
+              file_path,
+              state.hash_algorithm,
+              signature,
+              state.public_key,
+              dek
+            )
+        end
       else
         false ->
           {:error, :enoent}
@@ -135,8 +194,11 @@ defmodule Peridiod.Cache do
     file_sig_path = file_path <> ".sig"
 
     reply =
-      with hash <- hash(file_path, state.hash_algorithm),
-           true <- :crypto.verify(:eddsa, :sha256, hash, signature, [public_key, :ed25519]),
+      with plaintext_hash <- hash(file_path, state.hash_algorithm),
+           true <-
+             :crypto.verify(:eddsa, :sha256, plaintext_hash, signature, [public_key, :ed25519]),
+           :ok <- maybe_encrypt_file(file_path, state),
+           hash <- hash(file_path, state.hash_algorithm),
            signature <- sign(hash, state.hash_algorithm, state.private_key),
            :ok <- File.write(file_sig_path, signature) do
         :ok
@@ -158,7 +220,8 @@ defmodule Peridiod.Cache do
     file_sig_path = file_path <> ".sig"
 
     reply =
-      with hash <- hash(file_path, state.hash_algorithm),
+      with :ok <- maybe_encrypt_file(file_path, state),
+           hash <- hash(file_path, state.hash_algorithm),
            signature <- sign(hash, state.hash_algorithm, state.private_key),
            :ok <- File.write(file_sig_path, signature) do
         :ok
@@ -195,6 +258,23 @@ defmodule Peridiod.Cache do
     {:reply, path, state}
   end
 
+  def handle_call({:decrypt_to_tempfile, file}, _from, state) do
+    {:reply, do_decrypt_to_tempfile(file, state), state}
+  end
+
+  def handle_call({:cleanup_tempfile, path}, _from, state) do
+    tmp_dir = Path.join(state.path, ".tmp") <> "/"
+
+    reply =
+      if String.starts_with?(path, tmp_dir) do
+        File.rm(path)
+      else
+        :ok
+      end
+
+    {:reply, reply, state}
+  end
+
   def handle_call({:rm, file}, _from, state) do
     path = Path.join([state.path, file])
     file_sig_path = path <> ".sig"
@@ -207,40 +287,46 @@ defmodule Peridiod.Cache do
     {:reply, File.rm_rf(path), state}
   end
 
-  defp do_write(file, content, %{
-         hash_algorithm: hash_algorithm,
-         private_key: private_key,
-         path: path
-       }) do
-    file_path = Path.join([path, file])
+  defp do_write(file, content, state) do
+    file_path = Path.join([state.path, file])
     file_sig_path = file_path <> ".sig"
     dir = Path.dirname(file_path)
 
+    stored_content =
+      case state.dek do
+        nil -> content
+        dek -> Encryption.encrypt(content, dek)
+      end
+
     with :ok <- File.mkdir_p(dir),
-         :ok <- File.write(file_path, content),
-         hash <- hash(file_path, hash_algorithm),
-         signature <- sign(hash, hash_algorithm, private_key),
+         :ok <- File.write(file_path, stored_content),
+         hash <- hash(file_path, state.hash_algorithm),
+         signature <- sign(hash, state.hash_algorithm, state.private_key),
          :ok <- File.write(file_sig_path, signature) do
       :ok
     end
   end
 
-  defp do_read(file, %{
-         hash_algorithm: hash_algorithm,
-         public_key: public_key,
-         path: path
-       }) do
-    file_path = Path.join([path, file])
+  defp do_read(file, state) do
+    file_path = Path.join([state.path, file])
     file_sig_path = file_path <> ".sig"
 
     with {:ok, signature_hex} <- File.read(file_sig_path),
          {:ok, signature} <- Base.decode16(signature_hex, case: :mixed),
          true <- File.exists?(file_path) do
-      current_hash = hash(file_path, hash_algorithm)
+      current_hash = hash(file_path, state.hash_algorithm)
 
-      case verified?(current_hash, hash_algorithm, signature, public_key) do
-        true -> File.read(file_path)
-        false -> {:error, :invalid_signature}
+      case verified?(current_hash, state.hash_algorithm, signature, state.public_key) do
+        true ->
+          with {:ok, raw} <- File.read(file_path) do
+            case state.dek do
+              nil -> {:ok, raw}
+              dek -> Encryption.decrypt(raw, dek)
+            end
+          end
+
+        false ->
+          {:error, :invalid_signature}
       end
     else
       false -> {:error, :enoent}
@@ -265,5 +351,78 @@ defmodule Peridiod.Cache do
       end,
       fn _hash -> :ok end
     )
+  end
+
+  defp do_decrypt_to_tempfile(file, state) do
+    file_path = Path.join([state.path, file])
+    file_sig_path = file_path <> ".sig"
+
+    with {:ok, signature_hex} <- File.read(file_sig_path),
+         {:ok, signature} <- Base.decode16(signature_hex, case: :mixed),
+         true <- File.exists?(file_path) do
+      current_hash = hash(file_path, state.hash_algorithm)
+
+      case verified?(current_hash, state.hash_algorithm, signature, state.public_key) do
+        true ->
+          case state.dek do
+            nil ->
+              {:ok, file_path}
+
+            dek ->
+              temp_dir = Path.join(state.path, ".tmp")
+              Encryption.decrypt_to_tempfile(file_path, temp_dir, dek)
+          end
+
+        false ->
+          {:error, :invalid_signature}
+      end
+    else
+      false -> {:error, :enoent}
+      :error -> {:error, :invalid_signature}
+      error -> error
+    end
+  end
+
+  defp maybe_encrypt_file(_file_path, %{dek: nil}), do: :ok
+
+  defp maybe_encrypt_file(file_path, %{dek: dek}) do
+    tmp_path = file_path <> ".enc"
+
+    case Encryption.encrypt_file(file_path, tmp_path, dek) do
+      :ok ->
+        case File.rename(tmp_path, file_path) do
+          :ok ->
+            :ok
+
+          error ->
+            File.rm(tmp_path)
+            error
+        end
+
+      error ->
+        File.rm(tmp_path)
+        error
+    end
+  end
+
+  defp init_cache_dir(cache_dir) do
+    case File.stat(cache_dir) do
+      {:ok, %File.Stat{mode: mode}} ->
+        perm = band(mode, 0o777)
+
+        if perm != 0o700 do
+          Logger.warning(
+            "[Cache] cache_dir #{cache_dir} has mode 0#{Integer.to_string(perm, 8)}, " <>
+              "expected 0700. Cached data may be readable by other users."
+          )
+        end
+
+      {:error, :enoent} ->
+        :ok = File.mkdir_p(cache_dir)
+        File.chmod(cache_dir, 0o700)
+
+      {:error, reason} ->
+        Logger.warning("[Cache] Cannot stat cache_dir #{cache_dir}: #{inspect(reason)}")
+    end
   end
 end

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -195,8 +195,7 @@ defmodule Peridiod.Cache do
 
     reply =
       with plaintext_hash <- hash(file_path, state.hash_algorithm),
-           true <-
-             :crypto.verify(:eddsa, :sha256, plaintext_hash, signature, [public_key, :ed25519]),
+           true <- Peridiod.Binary.valid_signature?(plaintext_hash, signature, public_key),
            :ok <- maybe_encrypt_file(file_path, state),
            hash <- hash(file_path, state.hash_algorithm),
            signature <- sign(hash, state.hash_algorithm, state.private_key),
@@ -402,6 +401,7 @@ defmodule Peridiod.Cache do
 
       error ->
         File.rm(tmp_path)
+        File.rm(file_path)
         error
     end
   end

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -129,6 +129,7 @@ defmodule Peridiod.Cache do
 
         case Encryption.regenerate_dek(cache_dir, private_key) do
           {:ok, dek} ->
+            purge_stale_encrypted_files(cache_dir)
             cleanup_orphaned_plaintext(cache_dir)
             {:ok, %{state | dek: dek}}
 
@@ -144,13 +145,7 @@ defmodule Peridiod.Cache do
   end
 
   def handle_call({:exists?, file}, _from, state) do
-    resp =
-      case do_read(file, state) do
-        {:ok, _content} -> true
-        _error -> false
-      end
-
-    {:reply, resp, state}
+    {:reply, do_exists?(file, state), state}
   end
 
   def handle_call({:read, file}, _from, state) do
@@ -197,6 +192,9 @@ defmodule Peridiod.Cache do
     file_path = Path.join([state.path, file])
     dir = Path.dirname(file_path)
 
+    # Chunks land as plaintext during streaming; write_stream_finish[_local] encrypts
+    # the completed file in one pass. cleanup_orphaned_plaintext/1 removes remnants
+    # if the process is interrupted before finish is called.
     reply =
       with :ok <- File.mkdir_p(dir),
            :ok <- File.write(file_path, data, [:append, :binary]) do
@@ -339,8 +337,15 @@ defmodule Peridiod.Cache do
         true ->
           with {:ok, raw} <- File.read(file_path) do
             case state.dek do
-              nil -> {:ok, raw}
-              dek -> Encryption.decrypt(raw, dek)
+              nil ->
+                {:ok, raw}
+
+              dek ->
+                case Encryption.decrypt(raw, dek) do
+                  # Backward compat: file predates encryption or encryption was disabled
+                  {:error, :invalid_format} -> {:ok, raw}
+                  result -> result
+                end
             end
           end
 
@@ -417,7 +422,7 @@ defmodule Peridiod.Cache do
             File.rm(tmp_path)
 
             Logger.error(
-              "[Cache] Failed to replace #{file_path} with encrypted copy: #{inspect(error)}. Plaintext left in place; will be cleaned up on next startup."
+              "[Cache] Failed to replace #{file_path} with encrypted copy: #{inspect(error)}. Plaintext left in place."
             )
 
             error
@@ -427,7 +432,7 @@ defmodule Peridiod.Cache do
         File.rm(tmp_path)
 
         Logger.error(
-          "[Cache] Failed to encrypt #{file_path}: #{inspect(error)}. Plaintext left in place; will be cleaned up on next startup."
+          "[Cache] Failed to encrypt #{file_path}: #{inspect(error)}. Plaintext left in place."
         )
 
         error
@@ -481,6 +486,51 @@ defmodule Peridiod.Cache do
               if String.ends_with?(entry, ".enc") do
                 Logger.debug("[Cache] Removing stray .enc file: #{path}")
                 File.rm(path)
+              end
+
+            _ ->
+              :ok
+          end
+        end)
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp do_exists?(file, state) do
+    file_path = Path.join([state.path, file])
+    file_sig_path = file_path <> ".sig"
+
+    with {:ok, sig_hex} <- File.read(file_sig_path),
+         {:ok, sig} <- Base.decode16(sig_hex, case: :mixed),
+         true <- File.exists?(file_path) do
+      current_hash = hash(file_path, state.hash_algorithm)
+      verified?(current_hash, state.hash_algorithm, sig, state.public_key)
+    else
+      _ -> false
+    end
+  end
+
+  # After DEK rotation, purge files that were encrypted with the old DEK — they can
+  # no longer be decrypted and will be re-downloaded on the next update.
+  defp purge_stale_encrypted_files(dir) do
+    case File.ls(dir) do
+      {:ok, entries} ->
+        Enum.each(entries, fn entry ->
+          path = Path.join(dir, entry)
+
+          case File.lstat(path) do
+            {:ok, %File.Stat{type: :directory}} when entry not in [".tmp"] ->
+              purge_stale_encrypted_files(path)
+
+            {:ok, %File.Stat{type: :regular}} ->
+              if entry not in [".dek", ".dek.sig"] and
+                   not String.ends_with?(entry, ".sig") and
+                   Encryption.encrypted?(path) do
+                Logger.debug("[Cache] Purging encrypted file (stale DEK): #{path}")
+                File.rm(path)
+                File.rm(path <> ".sig")
               end
 
             _ ->

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -107,18 +107,35 @@ defmodule Peridiod.Cache do
         {:ok, nil}
       end
 
+    state = %{
+      path: cache_dir,
+      hash_algorithm: hash_algorithm,
+      private_key: private_key,
+      public_key: public_key,
+      dek: nil
+    }
+
     case dek_result do
       {:ok, dek} ->
         if dek != nil, do: cleanup_orphaned_plaintext(cache_dir)
+        {:ok, %{state | dek: dek}}
 
-        {:ok,
-         %{
-           path: cache_dir,
-           hash_algorithm: hash_algorithm,
-           private_key: private_key,
-           public_key: public_key,
-           dek: dek
-         }}
+      {:error, :dek_signature_invalid} ->
+        Logger.warning(
+          "[Cache] DEK signature invalid — device key may have been rotated. " <>
+            "Regenerating DEK; previously cached encrypted files will require re-download. " <>
+            "If key rotation was not expected, investigate for potential tampering."
+        )
+
+        case Encryption.regenerate_dek(cache_dir, private_key) do
+          {:ok, dek} ->
+            cleanup_orphaned_plaintext(cache_dir)
+            {:ok, %{state | dek: dek}}
+
+          {:error, reason} ->
+            Logger.error("[Cache] Failed to regenerate DEK: #{inspect(reason)}")
+            {:stop, reason}
+        end
 
       {:error, reason} ->
         Logger.error("[Cache] Failed to load or create DEK: #{inspect(reason)}")
@@ -398,23 +415,35 @@ defmodule Peridiod.Cache do
 
           error ->
             File.rm(tmp_path)
-            File.rm(file_path)
+
+            Logger.error(
+              "[Cache] Failed to replace #{file_path} with encrypted copy: #{inspect(error)}. Plaintext left in place; will be cleaned up on next startup."
+            )
+
             error
         end
 
       error ->
         File.rm(tmp_path)
-        File.rm(file_path)
+
+        Logger.error(
+          "[Cache] Failed to encrypt #{file_path}: #{inspect(error)}. Plaintext left in place; will be cleaned up on next startup."
+        )
+
         error
     end
   end
 
-  # Remove plaintext temp files left behind by decrypt_to_tempfile calls that were
-  # interrupted before the caller could clean up. Called on startup when encryption
-  # is enabled so plaintext never persists across restarts.
+  # Remove leftover plaintext artifacts from previous interrupted operations.
+  # Called on startup when encryption is enabled.
   defp cleanup_orphaned_plaintext(cache_dir) do
-    tmp_dir = Path.join(cache_dir, ".tmp")
+    # Decrypted temp files from interrupted decrypt_to_tempfile calls
+    cleanup_tmp_dir(Path.join(cache_dir, ".tmp"))
+    # Stray .enc files from interrupted maybe_encrypt_file calls
+    cleanup_enc_files(cache_dir)
+  end
 
+  defp cleanup_tmp_dir(tmp_dir) do
     case File.ls(tmp_dir) do
       {:ok, entries} ->
         Enum.each(entries, fn entry ->
@@ -432,6 +461,32 @@ defmodule Peridiod.Cache do
 
       {:error, :enoent} ->
         :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp cleanup_enc_files(dir) do
+    case File.ls(dir) do
+      {:ok, entries} ->
+        Enum.each(entries, fn entry ->
+          path = Path.join(dir, entry)
+
+          case File.lstat(path) do
+            {:ok, %File.Stat{type: :directory}} when entry != ".tmp" ->
+              cleanup_enc_files(path)
+
+            {:ok, %File.Stat{type: :regular}} ->
+              if String.ends_with?(entry, ".enc") do
+                Logger.debug("[Cache] Removing stray .enc file: #{path}")
+                File.rm(path)
+              end
+
+            _ ->
+              :ok
+          end
+        end)
 
       _ ->
         :ok

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -100,28 +100,28 @@ defmodule Peridiod.Cache do
 
     init_cache_dir(cache_dir)
 
-    dek =
+    dek_result =
       if encryption_enabled do
-        case Encryption.load_or_create_dek(cache_dir, private_key, public_key) do
-          {:ok, dek} ->
-            dek
-
-          {:error, reason} ->
-            Logger.error("[Cache] Failed to load or create DEK: #{inspect(reason)}")
-            nil
-        end
+        Encryption.load_or_create_dek(cache_dir, private_key, public_key)
       else
-        nil
+        {:ok, nil}
       end
 
-    {:ok,
-     %{
-       path: cache_dir,
-       hash_algorithm: hash_algorithm,
-       private_key: private_key,
-       public_key: public_key,
-       dek: dek
-     }}
+    case dek_result do
+      {:ok, dek} ->
+        {:ok,
+         %{
+           path: cache_dir,
+           hash_algorithm: hash_algorithm,
+           private_key: private_key,
+           public_key: public_key,
+           dek: dek
+         }}
+
+      {:error, reason} ->
+        Logger.error("[Cache] Failed to load or create DEK: #{inspect(reason)}")
+        {:stop, reason}
+    end
   end
 
   def handle_call({:exists?, file}, _from, state) do
@@ -263,11 +263,12 @@ defmodule Peridiod.Cache do
   end
 
   def handle_call({:cleanup_tempfile, path}, _from, state) do
-    tmp_dir = Path.join(state.path, ".tmp") <> "/"
+    tmp_dir = Path.expand(Path.join(state.path, ".tmp"))
+    expanded = Path.expand(path)
 
     reply =
-      if String.starts_with?(path, tmp_dir) do
-        File.rm(path)
+      if String.starts_with?(expanded, tmp_dir <> "/") do
+        File.rm(expanded)
       else
         :ok
       end

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -411,6 +411,7 @@ defmodule Peridiod.Cache do
 
   defp maybe_encrypt_file(file_path, %{dek: dek}) do
     tmp_path = file_path <> ".enc"
+    sig_path = file_path <> ".sig"
 
     case Encryption.encrypt_file(file_path, tmp_path, dek) do
       :ok ->
@@ -420,9 +421,11 @@ defmodule Peridiod.Cache do
 
           error ->
             File.rm(tmp_path)
+            File.rm(file_path)
+            File.rm(sig_path)
 
             Logger.error(
-              "[Cache] Failed to replace #{file_path} with encrypted copy: #{inspect(error)}. Plaintext left in place."
+              "[Cache] Failed to replace #{file_path} with encrypted copy: #{inspect(error)}. Plaintext removed to preserve at-rest encryption guarantee; content will be re-downloaded."
             )
 
             error
@@ -430,9 +433,11 @@ defmodule Peridiod.Cache do
 
       error ->
         File.rm(tmp_path)
+        File.rm(file_path)
+        File.rm(sig_path)
 
         Logger.error(
-          "[Cache] Failed to encrypt #{file_path}: #{inspect(error)}. Plaintext left in place."
+          "[Cache] Failed to encrypt #{file_path}: #{inspect(error)}. Plaintext removed to preserve at-rest encryption guarantee; content will be re-downloaded."
         )
 
         error

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -49,6 +49,17 @@ defmodule Peridiod.Cache.Encryption do
     end
   end
 
+  @doc """
+  Delete the existing DEK and generate a fresh one signed with `private_key`.
+  Used when key rotation is detected (DEK signature no longer verifies under
+  the current key). Returns `{:ok, new_dek}` or `{:error, reason}`.
+  """
+  def regenerate_dek(cache_dir, private_key) do
+    File.rm(dek_path(cache_dir))
+    File.rm(dek_sig_path(cache_dir))
+    generate_and_save_dek(dek_path(cache_dir), dek_sig_path(cache_dir), private_key)
+  end
+
   defp load_dek(dek_path, dek_sig_path, public_key) do
     with {:ok, dek} <- File.read(dek_path),
          :ok <- if(byte_size(dek) == 32, do: :ok, else: {:error, :invalid_dek_size}),

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -51,7 +51,7 @@ defmodule Peridiod.Cache.Encryption do
 
   defp load_dek(dek_path, dek_sig_path, public_key) do
     with {:ok, dek} <- File.read(dek_path),
-         :ok <- (if byte_size(dek) == 32, do: :ok, else: {:error, :invalid_dek_size}),
+         :ok <- if(byte_size(dek) == 32, do: :ok, else: {:error, :invalid_dek_size}),
          {:ok, sig_hex} <- File.read(dek_sig_path),
          {:ok, sig} <- decode_sig_hex(sig_hex) do
       hash = :crypto.hash(:sha256, dek) |> Base.encode16(case: :lower)

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -175,13 +175,15 @@ defmodule Peridiod.Cache.Encryption do
     file_nonce = :crypto.strong_rand_bytes(8)
     header = <<@version::8, file_nonce::binary-8, @chunk_size::32>>
 
-    with {:ok, in_file} <- File.open(plaintext_path, [:read, :binary]),
-         {:ok, out_file} <- File.open(encrypted_path, [:write, :binary]) do
-      IO.binwrite(out_file, header)
-      result = encrypt_file_chunks(in_file, out_file, file_nonce, dek, 0)
-      File.close(in_file)
-      File.close(out_file)
-      result
+    case File.open(plaintext_path, [:read, :binary], fn in_file ->
+           File.open(encrypted_path, [:write, :binary], fn out_file ->
+             IO.binwrite(out_file, header)
+             encrypt_file_chunks(in_file, out_file, file_nonce, dek, 0)
+           end)
+         end) do
+      {:ok, {:ok, result}} -> result
+      {:ok, {:error, reason}} -> {:error, reason}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -51,8 +51,9 @@ defmodule Peridiod.Cache.Encryption do
 
   defp load_dek(dek_path, dek_sig_path, public_key) do
     with {:ok, dek} <- File.read(dek_path),
+         :ok <- (if byte_size(dek) == 32, do: :ok, else: {:error, :invalid_dek_size}),
          {:ok, sig_hex} <- File.read(dek_sig_path),
-         {:ok, sig} <- Base.decode16(sig_hex, case: :mixed) do
+         {:ok, sig} <- decode_sig_hex(sig_hex) do
       hash = :crypto.hash(:sha256, dek) |> Base.encode16(case: :lower)
 
       if verified?(hash, :sha256, sig, public_key) do
@@ -61,6 +62,13 @@ defmodule Peridiod.Cache.Encryption do
         Logger.error("[Cache.Encryption] DEK signature verification failed — possible tampering")
         {:error, :dek_signature_invalid}
       end
+    end
+  end
+
+  defp decode_sig_hex(sig_hex) do
+    case Base.decode16(String.trim(sig_hex), case: :mixed) do
+      :error -> {:error, :invalid_dek_signature_format}
+      result -> result
     end
   end
 
@@ -210,7 +218,7 @@ defmodule Peridiod.Cache.Encryption do
          {:ok, in_file} <- File.open(encrypted_path, [:read, :binary]) do
       case IO.binread(in_file, @header_size) do
         <<@version::8, file_nonce::binary-8, _chunk_size::32>> ->
-          case File.open(temp_path, [:write, :binary]) do
+          case File.open(temp_path, [:write, :binary, :exclusive]) do
             {:ok, out_file} ->
               result = decrypt_file_chunks(in_file, out_file, file_nonce, dek, 0)
               File.close(in_file)
@@ -218,6 +226,7 @@ defmodule Peridiod.Cache.Encryption do
 
               case result do
                 :ok ->
+                  File.chmod(temp_path, 0o600)
                   {:ok, temp_path}
 
                 error ->

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -16,6 +16,35 @@ defmodule Peridiod.Cache.Encryption do
   `cache_dir/.dek`, with its signature at `cache_dir/.dek.sig`. The DEK is
   signed with the device's existing asymmetric key so that tampering is
   detectable on startup.
+
+  ## Threat model
+
+  This scheme provides:
+
+  - **At-rest encryption for compliance** (SOC 2 and similar): cache contents
+    are never persisted to disk in plaintext under normal operation.
+  - **Tamper detection**: the DEK is signed with the device key, so an attacker
+    cannot substitute a DEK of their own choosing (to plant attacker-controlled
+    cache content) without the signature check failing on next startup.
+  - **Logical access separation**: the DEK file is `chmod 0600`. Other users on
+    the same device cannot read cache contents, even if a bug leaves an
+    individual cache file with looser permissions.
+  - **Scoped exfiltration resistance**: a backup that captures cache binaries
+    but misses `.dek` (pattern-based copies, selective sync) yields opaque data.
+
+  It does **not** provide confidentiality against:
+
+  - An attacker with filesystem read access to `cache_dir/.dek` — they can
+    decrypt every cache file. On `file`, `env`, and `uboot-env` key sources the
+    device private key and the DEK are both on disk, so filesystem read access
+    generally defeats the entire scheme.
+  - Raw disk exfiltration (image dumps, recovered drives).
+
+  For stronger confidentiality the DEK would need to be *wrapped* (encrypted)
+  by the device key rather than stored in plaintext with a signature. That
+  requires encrypt/decrypt or key-agreement primitives in `Peridiod.Crypto`
+  (not present today) and, for `pkcs11` sources, `C_DeriveKey` / `C_Unwrap`
+  support on the token — neither is currently exercised.
   """
 
   import Peridiod.Crypto, only: [sign: 3, verified?: 4]

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -26,6 +26,7 @@ defmodule Peridiod.Cache.Encryption do
   @chunk_size 65_536
   @tag_size 16
   @header_size 13
+  @max_chunk_len @chunk_size + @tag_size
   @aad "peridiod-cache-v1"
 
   # ---------------------------------------------------------------------------
@@ -265,7 +266,7 @@ defmodule Peridiod.Cache.Encryption do
         :ok
 
       <<len::32>> ->
-        if len < @tag_size do
+        if len < @tag_size or len > @max_chunk_len do
           {:error, :invalid_chunk_length}
         else
           case IO.binread(in_file, len) do
@@ -349,7 +350,7 @@ defmodule Peridiod.Cache.Encryption do
 
               {[eof_event], {:done, file}}
 
-            <<len::32>> = len_bytes when len >= @tag_size ->
+            <<len::32>> = len_bytes when len >= @tag_size and len <= @max_chunk_len ->
               case IO.binread(file, len) do
                 chunk_data when is_binary(chunk_data) and byte_size(chunk_data) == len ->
                   hash_acc =

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -1,0 +1,370 @@
+defmodule Peridiod.Cache.Encryption do
+  @moduledoc """
+  AES-256-GCM encryption for the Peridiod file cache.
+
+  Files are stored on disk in a chunked encrypted format:
+
+    [1 byte version][8 byte file nonce][4 byte chunk size as uint32-be]
+    [4 byte chunk len | ciphertext | 16-byte GCM tag] per chunk
+
+  Each chunk uses a nonce derived from the per-file nonce and chunk index,
+  preventing chunk-reordering attacks. The GCM tag authenticates each chunk
+  independently, so corruption is detected at the chunk boundary rather than
+  requiring the entire file to be read before verification.
+
+  The Data Encryption Key (DEK) is a random 256-bit symmetric key stored at
+  `cache_dir/.dek`, with its signature at `cache_dir/.dek.sig`. The DEK is
+  signed with the device's existing asymmetric key so that tampering is
+  detectable on startup.
+  """
+
+  import Peridiod.Crypto, only: [sign: 3, verified?: 4]
+
+  require Logger
+
+  @version 1
+  @chunk_size 65_536
+  @tag_size 16
+  @header_size 13
+  @aad "peridiod-cache-v1"
+
+  # ---------------------------------------------------------------------------
+  # DEK lifecycle
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Load the DEK from disk, or generate and persist a new one if it does not exist.
+  Returns `{:ok, dek}` on success or `{:error, reason}` on failure.
+  """
+  def load_or_create_dek(cache_dir, private_key, public_key) do
+    :ok = File.mkdir_p(cache_dir)
+    dek_path = dek_path(cache_dir)
+    dek_sig_path = dek_sig_path(cache_dir)
+
+    if File.exists?(dek_path) and File.exists?(dek_sig_path) do
+      load_dek(dek_path, dek_sig_path, public_key)
+    else
+      generate_and_save_dek(dek_path, dek_sig_path, private_key)
+    end
+  end
+
+  defp load_dek(dek_path, dek_sig_path, public_key) do
+    with {:ok, dek} <- File.read(dek_path),
+         {:ok, sig_hex} <- File.read(dek_sig_path),
+         {:ok, sig} <- Base.decode16(sig_hex, case: :mixed) do
+      hash = :crypto.hash(:sha256, dek) |> Base.encode16(case: :lower)
+
+      if verified?(hash, :sha256, sig, public_key) do
+        {:ok, dek}
+      else
+        Logger.error("[Cache.Encryption] DEK signature verification failed — possible tampering")
+        {:error, :dek_signature_invalid}
+      end
+    end
+  end
+
+  defp generate_and_save_dek(dek_path, dek_sig_path, private_key) do
+    dek = :crypto.strong_rand_bytes(32)
+    hash = :crypto.hash(:sha256, dek) |> Base.encode16(case: :lower)
+    sig_hex = sign(hash, :sha256, private_key)
+
+    with :ok <- File.write(dek_path, dek),
+         :ok <- File.chmod(dek_path, 0o600),
+         :ok <- File.write(dek_sig_path, sig_hex),
+         :ok <- File.chmod(dek_sig_path, 0o600) do
+      {:ok, dek}
+    end
+  end
+
+  defp dek_path(cache_dir), do: Path.join(cache_dir, ".dek")
+  defp dek_sig_path(cache_dir), do: Path.join(cache_dir, ".dek.sig")
+
+  # ---------------------------------------------------------------------------
+  # One-shot encrypt / decrypt (for small files: manifests, stamps)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Encrypt `plaintext` with `dek`. Returns the encrypted binary.
+  """
+  def encrypt(plaintext, dek) when is_binary(plaintext) and byte_size(dek) == 32 do
+    file_nonce = :crypto.strong_rand_bytes(8)
+    header = <<@version::8, file_nonce::binary-8, @chunk_size::32>>
+    chunks = encrypt_chunks_binary(plaintext, file_nonce, dek, 0, [])
+    IO.iodata_to_binary([header | Enum.reverse(chunks)])
+  end
+
+  defp encrypt_chunks_binary(<<>>, _nonce, _dek, _idx, acc), do: acc
+
+  defp encrypt_chunks_binary(data, file_nonce, dek, idx, acc) do
+    take = min(byte_size(data), @chunk_size)
+    <<chunk::binary-size(take), rest::binary>> = data
+    nonce = <<idx::32, file_nonce::binary>>
+
+    {ct, tag} =
+      :crypto.crypto_one_time_aead(:aes_256_gcm, dek, nonce, chunk, @aad, @tag_size, true)
+
+    len = byte_size(ct) + @tag_size
+
+    encrypt_chunks_binary(rest, file_nonce, dek, idx + 1, [
+      <<len::32, ct::binary, tag::binary>> | acc
+    ])
+  end
+
+  @doc """
+  Decrypt an encrypted binary produced by `encrypt/2`.
+  Returns `{:ok, plaintext}` or `{:error, reason}`.
+  """
+  def decrypt(data, dek) when is_binary(data) and byte_size(dek) == 32 do
+    case data do
+      <<@version::8, file_nonce::binary-8, _chunk_size::32, rest::binary>> ->
+        decrypt_chunks_binary(rest, file_nonce, dek, 0, [])
+
+      _ ->
+        {:error, :invalid_format}
+    end
+  end
+
+  defp decrypt_chunks_binary(<<>>, _file_nonce, _dek, _idx, acc) do
+    {:ok, IO.iodata_to_binary(Enum.reverse(acc))}
+  end
+
+  defp decrypt_chunks_binary(<<len::32, rest::binary>>, file_nonce, dek, idx, acc) do
+    case rest do
+      <<chunk_data::binary-size(len), remaining::binary>> ->
+        ct = binary_part(chunk_data, 0, len - @tag_size)
+        tag = binary_part(chunk_data, len - @tag_size, @tag_size)
+        nonce = <<idx::32, file_nonce::binary>>
+
+        case :crypto.crypto_one_time_aead(:aes_256_gcm, dek, nonce, ct, @aad, tag, false) do
+          plaintext when is_binary(plaintext) ->
+            decrypt_chunks_binary(remaining, file_nonce, dek, idx + 1, [plaintext | acc])
+
+          :error ->
+            {:error, :authentication_failed}
+        end
+
+      _ ->
+        {:error, :truncated_chunk}
+    end
+  end
+
+  defp decrypt_chunks_binary(_, _, _, _, _), do: {:error, :invalid_chunk_header}
+
+  # ---------------------------------------------------------------------------
+  # File-level encrypt / decrypt (for streaming write finish)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Encrypt the file at `plaintext_path`, writing the result to `encrypted_path`.
+  Reads plaintext in `@chunk_size` blocks so memory usage is bounded.
+  """
+  def encrypt_file(plaintext_path, encrypted_path, dek) when byte_size(dek) == 32 do
+    file_nonce = :crypto.strong_rand_bytes(8)
+    header = <<@version::8, file_nonce::binary-8, @chunk_size::32>>
+
+    with {:ok, in_file} <- File.open(plaintext_path, [:read, :binary]),
+         {:ok, out_file} <- File.open(encrypted_path, [:write, :binary]) do
+      IO.binwrite(out_file, header)
+      result = encrypt_file_chunks(in_file, out_file, file_nonce, dek, 0)
+      File.close(in_file)
+      File.close(out_file)
+      result
+    end
+  end
+
+  defp encrypt_file_chunks(in_file, out_file, file_nonce, dek, idx) do
+    case IO.binread(in_file, @chunk_size) do
+      :eof ->
+        :ok
+
+      data when is_binary(data) ->
+        nonce = <<idx::32, file_nonce::binary>>
+
+        {ct, tag} =
+          :crypto.crypto_one_time_aead(:aes_256_gcm, dek, nonce, data, @aad, @tag_size, true)
+
+        len = byte_size(ct) + @tag_size
+        IO.binwrite(out_file, <<len::32, ct::binary, tag::binary>>)
+        encrypt_file_chunks(in_file, out_file, file_nonce, dek, idx + 1)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Decrypt the file at `encrypted_path` to a temporary file under `temp_dir`.
+  Returns `{:ok, temp_path}` on success; the caller is responsible for removing
+  the temp file when done.
+  """
+  def decrypt_to_tempfile(encrypted_path, temp_dir, dek) when byte_size(dek) == 32 do
+    rand_suffix = :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
+    temp_path = Path.join(temp_dir, ".tmp_#{rand_suffix}")
+
+    with :ok <- File.mkdir_p(temp_dir),
+         {:ok, in_file} <- File.open(encrypted_path, [:read, :binary]) do
+      case IO.binread(in_file, @header_size) do
+        <<@version::8, file_nonce::binary-8, _chunk_size::32>> ->
+          case File.open(temp_path, [:write, :binary]) do
+            {:ok, out_file} ->
+              result = decrypt_file_chunks(in_file, out_file, file_nonce, dek, 0)
+              File.close(in_file)
+              File.close(out_file)
+
+              case result do
+                :ok ->
+                  {:ok, temp_path}
+
+                error ->
+                  File.rm(temp_path)
+                  error
+              end
+
+            {:error, reason} ->
+              File.close(in_file)
+              {:error, reason}
+          end
+
+        _ ->
+          File.close(in_file)
+          {:error, :invalid_format}
+      end
+    end
+  end
+
+  defp decrypt_file_chunks(in_file, out_file, file_nonce, dek, idx) do
+    case IO.binread(in_file, 4) do
+      :eof ->
+        :ok
+
+      <<len::32>> ->
+        case IO.binread(in_file, len) do
+          chunk_data when is_binary(chunk_data) and byte_size(chunk_data) == len ->
+            ct = binary_part(chunk_data, 0, len - @tag_size)
+            tag = binary_part(chunk_data, len - @tag_size, @tag_size)
+            nonce = <<idx::32, file_nonce::binary>>
+
+            case :crypto.crypto_one_time_aead(:aes_256_gcm, dek, nonce, ct, @aad, tag, false) do
+              plaintext when is_binary(plaintext) ->
+                IO.binwrite(out_file, plaintext)
+                decrypt_file_chunks(in_file, out_file, file_nonce, dek, idx + 1)
+
+              :error ->
+                {:error, :authentication_failed}
+            end
+
+          _ ->
+            {:error, :truncated_chunk}
+        end
+
+      _ ->
+        {:error, :invalid_chunk_header}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Streaming decryption (for Cache.read_stream)
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns a lazy `Stream` that decrypts an encrypted cache file chunk by chunk.
+
+  The stream emits:
+  - `{:stream, plaintext_chunk}` — decrypted data, safe to pass to installers
+  - `{:eof, :valid_signature | :invalid_signature, ciphertext_hash}` — end of stream
+
+  The ciphertext is hashed as it is read and the hash is verified against
+  `signature` using `public_key` before emitting the final `:eof` event.
+  """
+  def decrypt_stream(file_path, algorithm, signature, public_key, dek)
+      when byte_size(dek) == 32 do
+    Stream.resource(
+      fn ->
+        {:ok, file} = File.open(file_path, [:read, :binary])
+        header = IO.binread(file, @header_size)
+        <<@version::8, file_nonce::binary-8, _::32>> = header
+        hash_acc = :crypto.hash_init(algorithm) |> :crypto.hash_update(header)
+        {:reading, file, file_nonce, 0, hash_acc}
+      end,
+      fn
+        {:done, _file} = acc ->
+          {:halt, acc}
+
+        {:reading, file, file_nonce, idx, hash_acc} ->
+          case IO.binread(file, 4) do
+            :eof ->
+              hash = :crypto.hash_final(hash_acc)
+              hash_encoded = Base.encode16(hash, case: :lower)
+
+              eof_event =
+                if verified?(hash_encoded, algorithm, signature, public_key) do
+                  {:eof, :valid_signature, hash_encoded}
+                else
+                  {:eof, :invalid_signature, hash_encoded}
+                end
+
+              {[eof_event], {:done, file}}
+
+            <<len::32>> = len_bytes ->
+              case IO.binread(file, len) do
+                chunk_data when is_binary(chunk_data) and byte_size(chunk_data) == len ->
+                  hash_acc =
+                    hash_acc
+                    |> :crypto.hash_update(len_bytes)
+                    |> :crypto.hash_update(chunk_data)
+
+                  ct = binary_part(chunk_data, 0, len - @tag_size)
+                  tag = binary_part(chunk_data, len - @tag_size, @tag_size)
+                  nonce = <<idx::32, file_nonce::binary>>
+
+                  case :crypto.crypto_one_time_aead(
+                         :aes_256_gcm,
+                         dek,
+                         nonce,
+                         ct,
+                         @aad,
+                         tag,
+                         false
+                       ) do
+                    plaintext when is_binary(plaintext) ->
+                      {[{:stream, plaintext}], {:reading, file, file_nonce, idx + 1, hash_acc}}
+
+                    :error ->
+                      {[{:eof, :invalid_signature, ""}], {:done, file}}
+                  end
+
+                _ ->
+                  {[{:eof, :invalid_signature, ""}], {:done, file}}
+              end
+
+            _ ->
+              {[{:eof, :invalid_signature, ""}], {:done, file}}
+          end
+      end,
+      fn
+        {:done, file} when not is_nil(file) -> File.close(file)
+        {:reading, file, _, _, _} -> File.close(file)
+        _ -> :ok
+      end
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # Format detection
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Returns `true` if the file at `file_path` starts with the encryption version byte.
+  """
+  def encrypted?(file_path) do
+    case File.open(file_path, [:read, :binary]) do
+      {:ok, file} ->
+        result = IO.binread(file, 1) == <<@version::8>>
+        File.close(file)
+        result
+
+      _ ->
+        false
+    end
+  end
+end

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -51,10 +51,12 @@ defmodule Peridiod.Cache.Encryption do
 
   require Logger
 
+  @magic "PDC1"
   @version 1
   @chunk_size 65_536
   @tag_size 16
-  @header_size 13
+  # 4-byte magic + 1-byte version + 8-byte file nonce + 4-byte chunk size
+  @header_size 17
   @max_chunk_len @chunk_size + @tag_size
   @aad "peridiod-cache-v1"
 
@@ -138,7 +140,7 @@ defmodule Peridiod.Cache.Encryption do
   """
   def encrypt(plaintext, dek) when is_binary(plaintext) and byte_size(dek) == 32 do
     file_nonce = :crypto.strong_rand_bytes(8)
-    header = <<@version::8, file_nonce::binary-8, @chunk_size::32>>
+    header = <<@magic, @version::8, file_nonce::binary-8, @chunk_size::32>>
     chunks = encrypt_chunks_binary(plaintext, file_nonce, dek, 0, [])
     IO.iodata_to_binary([header | Enum.reverse(chunks)])
   end
@@ -166,7 +168,7 @@ defmodule Peridiod.Cache.Encryption do
   """
   def decrypt(data, dek) when is_binary(data) and byte_size(dek) == 32 do
     case data do
-      <<@version::8, file_nonce::binary-8, _chunk_size::32, rest::binary>> ->
+      <<@magic, @version::8, file_nonce::binary-8, @chunk_size::32, rest::binary>> ->
         decrypt_chunks_binary(rest, file_nonce, dek, 0, [])
 
       _ ->
@@ -179,7 +181,7 @@ defmodule Peridiod.Cache.Encryption do
   end
 
   defp decrypt_chunks_binary(<<len::32, rest::binary>>, file_nonce, dek, idx, acc) do
-    if len < @tag_size do
+    if len < @tag_size or len > @max_chunk_len do
       {:error, :invalid_chunk_length}
     else
       case rest do
@@ -214,7 +216,7 @@ defmodule Peridiod.Cache.Encryption do
   """
   def encrypt_file(plaintext_path, encrypted_path, dek) when byte_size(dek) == 32 do
     file_nonce = :crypto.strong_rand_bytes(8)
-    header = <<@version::8, file_nonce::binary-8, @chunk_size::32>>
+    header = <<@magic, @version::8, file_nonce::binary-8, @chunk_size::32>>
 
     case File.open(plaintext_path, [:read, :binary], fn in_file ->
            File.open(encrypted_path, [:write, :binary], fn out_file ->
@@ -260,7 +262,7 @@ defmodule Peridiod.Cache.Encryption do
     with :ok <- File.mkdir_p(temp_dir),
          {:ok, in_file} <- File.open(encrypted_path, [:read, :binary]) do
       case IO.binread(in_file, @header_size) do
-        <<@version::8, file_nonce::binary-8, _chunk_size::32>> ->
+        <<@magic, @version::8, file_nonce::binary-8, @chunk_size::32>> ->
           case File.open(temp_path, [:write, :binary, :exclusive]) do
             {:ok, out_file} ->
               result = decrypt_file_chunks(in_file, out_file, file_nonce, dek, 0)
@@ -344,7 +346,7 @@ defmodule Peridiod.Cache.Encryption do
         case File.open(file_path, [:read, :binary]) do
           {:ok, file} ->
             case IO.binread(file, @header_size) do
-              <<@version::8, file_nonce::binary-8, _::32>> = header ->
+              <<@magic, @version::8, file_nonce::binary-8, @chunk_size::32>> = header ->
                 hash_acc = :crypto.hash_init(algorithm) |> :crypto.hash_update(header)
                 {:reading, file, file_nonce, 0, hash_acc}
 
@@ -429,12 +431,22 @@ defmodule Peridiod.Cache.Encryption do
   # ---------------------------------------------------------------------------
 
   @doc """
-  Returns `true` if the file at `file_path` starts with the encryption version byte.
+  Returns `true` if the file at `file_path` has a valid encryption header.
+
+  Validates all fixed header fields (magic, version, chunk size) — a single
+  byte prefix check is not reliable because arbitrary plaintext has a 1/256
+  chance of colliding with the version byte alone, which would cause stale-DEK
+  purging and format detection to misclassify plaintext as ciphertext.
   """
   def encrypted?(file_path) do
     case File.open(file_path, [:read, :binary]) do
       {:ok, file} ->
-        result = IO.binread(file, 1) == <<@version::8>>
+        result =
+          case IO.binread(file, @header_size) do
+            <<@magic, @version::8, _file_nonce::binary-8, @chunk_size::32>> -> true
+            _ -> false
+          end
+
         File.close(file)
         result
 

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -4,7 +4,8 @@ defmodule Peridiod.Cache.Encryption do
 
   Files are stored on disk in a chunked encrypted format:
 
-    [1 byte version][8 byte file nonce][4 byte chunk size as uint32-be]
+    [4 byte magic "PDC1"][1 byte version][8 byte file nonce]
+    [4 byte chunk size as uint32-be]
     [4 byte chunk len | ciphertext | 16-byte GCM tag] per chunk
 
   Each chunk uses a nonce derived from the per-file nonce and chunk index,

--- a/lib/peridiod/cache/encryption.ex
+++ b/lib/peridiod/cache/encryption.ex
@@ -37,14 +37,15 @@ defmodule Peridiod.Cache.Encryption do
   Returns `{:ok, dek}` on success or `{:error, reason}` on failure.
   """
   def load_or_create_dek(cache_dir, private_key, public_key) do
-    :ok = File.mkdir_p(cache_dir)
-    dek_path = dek_path(cache_dir)
-    dek_sig_path = dek_sig_path(cache_dir)
+    with :ok <- File.mkdir_p(cache_dir) do
+      dek_path = dek_path(cache_dir)
+      dek_sig_path = dek_sig_path(cache_dir)
 
-    if File.exists?(dek_path) and File.exists?(dek_sig_path) do
-      load_dek(dek_path, dek_sig_path, public_key)
-    else
-      generate_and_save_dek(dek_path, dek_sig_path, private_key)
+      if File.exists?(dek_path) and File.exists?(dek_sig_path) do
+        load_dek(dek_path, dek_sig_path, public_key)
+      else
+        generate_and_save_dek(dek_path, dek_sig_path, private_key)
+      end
     end
   end
 
@@ -129,22 +130,26 @@ defmodule Peridiod.Cache.Encryption do
   end
 
   defp decrypt_chunks_binary(<<len::32, rest::binary>>, file_nonce, dek, idx, acc) do
-    case rest do
-      <<chunk_data::binary-size(len), remaining::binary>> ->
-        ct = binary_part(chunk_data, 0, len - @tag_size)
-        tag = binary_part(chunk_data, len - @tag_size, @tag_size)
-        nonce = <<idx::32, file_nonce::binary>>
+    if len < @tag_size do
+      {:error, :invalid_chunk_length}
+    else
+      case rest do
+        <<chunk_data::binary-size(len), remaining::binary>> ->
+          ct = binary_part(chunk_data, 0, len - @tag_size)
+          tag = binary_part(chunk_data, len - @tag_size, @tag_size)
+          nonce = <<idx::32, file_nonce::binary>>
 
-        case :crypto.crypto_one_time_aead(:aes_256_gcm, dek, nonce, ct, @aad, tag, false) do
-          plaintext when is_binary(plaintext) ->
-            decrypt_chunks_binary(remaining, file_nonce, dek, idx + 1, [plaintext | acc])
+          case :crypto.crypto_one_time_aead(:aes_256_gcm, dek, nonce, ct, @aad, tag, false) do
+            plaintext when is_binary(plaintext) ->
+              decrypt_chunks_binary(remaining, file_nonce, dek, idx + 1, [plaintext | acc])
 
-          :error ->
-            {:error, :authentication_failed}
-        end
+            :error ->
+              {:error, :authentication_failed}
+          end
 
-      _ ->
-        {:error, :truncated_chunk}
+        _ ->
+          {:error, :truncated_chunk}
+      end
     end
   end
 
@@ -238,23 +243,27 @@ defmodule Peridiod.Cache.Encryption do
         :ok
 
       <<len::32>> ->
-        case IO.binread(in_file, len) do
-          chunk_data when is_binary(chunk_data) and byte_size(chunk_data) == len ->
-            ct = binary_part(chunk_data, 0, len - @tag_size)
-            tag = binary_part(chunk_data, len - @tag_size, @tag_size)
-            nonce = <<idx::32, file_nonce::binary>>
+        if len < @tag_size do
+          {:error, :invalid_chunk_length}
+        else
+          case IO.binread(in_file, len) do
+            chunk_data when is_binary(chunk_data) and byte_size(chunk_data) == len ->
+              ct = binary_part(chunk_data, 0, len - @tag_size)
+              tag = binary_part(chunk_data, len - @tag_size, @tag_size)
+              nonce = <<idx::32, file_nonce::binary>>
 
-            case :crypto.crypto_one_time_aead(:aes_256_gcm, dek, nonce, ct, @aad, tag, false) do
-              plaintext when is_binary(plaintext) ->
-                IO.binwrite(out_file, plaintext)
-                decrypt_file_chunks(in_file, out_file, file_nonce, dek, idx + 1)
+              case :crypto.crypto_one_time_aead(:aes_256_gcm, dek, nonce, ct, @aad, tag, false) do
+                plaintext when is_binary(plaintext) ->
+                  IO.binwrite(out_file, plaintext)
+                  decrypt_file_chunks(in_file, out_file, file_nonce, dek, idx + 1)
 
-              :error ->
-                {:error, :authentication_failed}
-            end
+                :error ->
+                  {:error, :authentication_failed}
+              end
 
-          _ ->
-            {:error, :truncated_chunk}
+            _ ->
+              {:error, :truncated_chunk}
+          end
         end
 
       _ ->
@@ -280,15 +289,28 @@ defmodule Peridiod.Cache.Encryption do
       when byte_size(dek) == 32 do
     Stream.resource(
       fn ->
-        {:ok, file} = File.open(file_path, [:read, :binary])
-        header = IO.binread(file, @header_size)
-        <<@version::8, file_nonce::binary-8, _::32>> = header
-        hash_acc = :crypto.hash_init(algorithm) |> :crypto.hash_update(header)
-        {:reading, file, file_nonce, 0, hash_acc}
+        case File.open(file_path, [:read, :binary]) do
+          {:ok, file} ->
+            case IO.binread(file, @header_size) do
+              <<@version::8, file_nonce::binary-8, _::32>> = header ->
+                hash_acc = :crypto.hash_init(algorithm) |> :crypto.hash_update(header)
+                {:reading, file, file_nonce, 0, hash_acc}
+
+              _ ->
+                File.close(file)
+                {:invalid, nil}
+            end
+
+          {:error, _reason} ->
+            {:invalid, nil}
+        end
       end,
       fn
         {:done, _file} = acc ->
           {:halt, acc}
+
+        {:invalid, _} ->
+          {[{:eof, :invalid_signature, ""}], {:done, nil}}
 
         {:reading, file, file_nonce, idx, hash_acc} ->
           case IO.binread(file, 4) do
@@ -305,7 +327,7 @@ defmodule Peridiod.Cache.Encryption do
 
               {[eof_event], {:done, file}}
 
-            <<len::32>> = len_bytes ->
+            <<len::32>> = len_bytes when len >= @tag_size ->
               case IO.binread(file, len) do
                 chunk_data when is_binary(chunk_data) and byte_size(chunk_data) == len ->
                   hash_acc =
@@ -338,6 +360,7 @@ defmodule Peridiod.Cache.Encryption do
               end
 
             _ ->
+              # Short chunk length (< @tag_size) or unexpected read result
               {[{:eof, :invalid_signature, ""}], {:done, file}}
           end
       end,

--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -60,6 +60,7 @@ defmodule Peridiod.Config do
 
   @type t() :: %__MODULE__{
           cache_dir: Path.t(),
+          cache_encryption_enabled: boolean(),
           cache_private_key: private_key(),
           cache_public_key: public_key(),
           cache_pid: pid() | module(),

--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -8,6 +8,7 @@ defmodule Peridiod.Config do
   require Logger
 
   defstruct cache_dir: "/var/lib/peridiod",
+            cache_encryption_enabled: true,
             cache_private_key: nil,
             cache_public_key: nil,
             cache_pid: Cache,
@@ -182,6 +183,7 @@ defmodule Peridiod.Config do
         config_file["device_api"]["certificate_path"]
       )
       |> override_if_set(:cache_dir, config_file["cache_dir"])
+      |> override_if_set(:cache_encryption_enabled, config_file["cache_encryption_enabled"])
       |> override_if_set(
         :distributions_cache_download,
         get_in(config_file, ["distributions", "cache_download"])

--- a/lib/peridiod/plan/step.ex
+++ b/lib/peridiod/plan/step.ex
@@ -55,16 +55,31 @@ defmodule Peridiod.Plan.Step do
          %{
            callback: callback,
            step_mod: step_mod,
-           step_state: step_state
+           step_state: step_state,
+           init_error: nil
          }}
 
+      # Carry the error in state and surface it when execute is called, so
+      # start_link/1's contract stays {:ok, pid}. init/1 itself may only return
+      # 2-tuple stop (not 3-tuple), and callers of Step expect to pattern-match
+      # {:ok, pid} before dispatching :execute.
       {:error, error, _step_state} ->
-        try_send(callback, {:error, error})
-        {:stop, :normal, nil}
+        {:ok,
+         %{
+           callback: callback,
+           step_mod: step_mod,
+           step_state: nil,
+           init_error: error
+         }}
 
       {:stop, reason, _step_state} ->
-        {:stop, reason, nil}
+        {:stop, reason}
     end
+  end
+
+  def handle_cast(:execute, %{init_error: error} = state) when not is_nil(error) do
+    try_send(state.callback, {:error, error})
+    {:stop, :normal, state}
   end
 
   def handle_cast(:execute, state) do

--- a/lib/peridiod/plan/step/binary_install.ex
+++ b/lib/peridiod/plan/step/binary_install.ex
@@ -234,8 +234,26 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
     binary_cache_file = Binary.cache_file(binary_metadata)
 
     case Cache.exists?(cache_pid, binary_cache_file) do
-      true -> Cache.decrypt_to_tempfile(cache_pid, binary_cache_file)
-      false -> {:error, :cache_file_missing}
+      true ->
+        case Cache.decrypt_to_tempfile(cache_pid, binary_cache_file) do
+          {:ok, _} = ok ->
+            ok
+
+          # Cached file predates encryption (stamp + valid plaintext sig, but no
+          # magic header). Drop the stale entry so the next attempt re-downloads;
+          # otherwise path-only installers stall in a permanent failure loop —
+          # init/1 returns the error before execute/1 runs, so the cache_rm in
+          # execute/1 and the stream :invalid_signature handler are never reached.
+          {:error, :invalid_format} = err ->
+            Binary.cache_rm(cache_pid, binary_metadata)
+            err
+
+          other ->
+            other
+        end
+
+      false ->
+        {:error, :cache_file_missing}
     end
   end
 

--- a/lib/peridiod/plan/step/binary_install.ex
+++ b/lib/peridiod/plan/step/binary_install.ex
@@ -74,10 +74,12 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
         {:noreply, state}
 
       {false, _} ->
+        Cache.cleanup_tempfile(state.cache_pid, source)
         Binary.cache_rm(state.cache_pid, state.binary_metadata)
         {:error, :invalid_hash, state}
 
       {_, false} ->
+        Cache.cleanup_tempfile(state.cache_pid, source)
         Binary.cache_rm(state.cache_pid, state.binary_metadata)
         {:error, :invalid_signature, state}
     end
@@ -194,8 +196,20 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
   end
 
   # Installer Callbacks
+  def handle_info({Installer, _binary_prn, :complete}, %{source: source} = state)
+      when is_binary(source) do
+    Cache.cleanup_tempfile(state.cache_pid, source)
+    {:stop, :normal, state}
+  end
+
   def handle_info({Installer, _binary_prn, :complete}, state) do
     {:stop, :normal, state}
+  end
+
+  def handle_info({Installer, _binary_prn, {:error, error}}, %{source: source} = state)
+      when is_binary(source) do
+    Cache.cleanup_tempfile(state.cache_pid, source)
+    {:error, error, state}
   end
 
   def handle_info({Installer, _binary_prn, {:error, error}}, state) do
@@ -212,31 +226,30 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
     end
   end
 
+  # Path-only installers receive a decrypted temp file so they can read plaintext.
   defp validate_source_interface(:cache, [:path], %{
          cache_pid: cache_pid,
          binary_metadata: binary_metadata
        }) do
-    expand_cache_path(binary_metadata, cache_pid)
-  end
+    binary_cache_file = Binary.cache_file(binary_metadata)
 
-  defp validate_source_interface(:cache, [:stream], %{
-         cache_pid: cache_pid,
-         binary_metadata: binary_metadata
-       }) do
-    case expand_cache_path(binary_metadata, cache_pid) do
-      {:ok, path} ->
-        {:ok, %URI{scheme: "file", path: path}}
-
-      error ->
-        error
+    case Cache.exists?(cache_pid, binary_cache_file) do
+      true -> Cache.decrypt_to_tempfile(cache_pid, binary_cache_file)
+      false -> {:error, :cache_file_missing}
     end
   end
 
-  defp validate_source_interface(:cache, [_ | _], %{
+  # Stream-capable installers go through Cache.read_stream which decrypts on the fly.
+  defp validate_source_interface(:cache, _interfaces, %{
          cache_pid: cache_pid,
          binary_metadata: binary_metadata
        }) do
-    expand_cache_path(binary_metadata, cache_pid)
+    binary_cache_file = Binary.cache_file(binary_metadata)
+
+    case Cache.exists?(cache_pid, binary_cache_file) do
+      true -> {:ok, :cache}
+      false -> {:error, :cache_file_missing}
+    end
   end
 
   defp validate_source_interface(%URI{scheme: "file", path: path}, [:path], _opts),
@@ -244,17 +257,4 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
 
   defp validate_source_interface(%URI{}, [:path], _opts), do: {:error, :unsupported_interface}
   defp validate_source_interface(%URI{} = source, [_ | _], _opts), do: {:ok, source}
-
-  defp expand_cache_path(binary_metadata, cache_pid) do
-    binary_cache_file = Binary.cache_file(binary_metadata)
-
-    case Cache.exists?(cache_pid, binary_cache_file) do
-      true ->
-        source = Cache.abs_path(cache_pid, binary_cache_file)
-        {:ok, source}
-
-      false ->
-        {:error, :cache_file_missing}
-    end
-  end
 end

--- a/test/peridiod/cache/encryption_test.exs
+++ b/test/peridiod/cache/encryption_test.exs
@@ -57,11 +57,13 @@ defmodule Peridiod.Cache.EncryptionTest do
     assert {:error, :invalid_format} = Encryption.decrypt(<<>>, @key)
   end
 
-  test "decrypt returns :invalid_format for plaintext that starts with the version byte" do
-    # Without a magic prefix, arbitrary plaintext starting with 0x01 would
-    # false-match the header and surface confusing downstream errors.
-    plaintext_colliding_on_version = <<1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
-    assert {:error, :invalid_format} = Encryption.decrypt(plaintext_colliding_on_version, @key)
+  test "decrypt returns :invalid_format for data with the magic prefix but invalid header fields" do
+    # The magic prefix alone isn't sufficient — the version byte and chunk size
+    # must also match. Input that starts with "PDC1" but has a zeroed-out
+    # version/chunk-size must be rejected at the header-match stage rather than
+    # surfacing a confusing downstream error.
+    malformed_with_magic_prefix = <<"PDC1", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+    assert {:error, :invalid_format} = Encryption.decrypt(malformed_with_magic_prefix, @key)
   end
 
   test "each encrypt call produces different ciphertext" do

--- a/test/peridiod/cache/encryption_test.exs
+++ b/test/peridiod/cache/encryption_test.exs
@@ -45,8 +45,8 @@ defmodule Peridiod.Cache.EncryptionTest do
   test "decrypt returns error for corrupted ciphertext" do
     plaintext = "secret data"
     encrypted = Encryption.encrypt(plaintext, @key)
-    # Flip a bit in the ciphertext body (after the 13-byte header + 4-byte chunk len)
-    <<header::binary-17, rest::binary>> = encrypted
+    # Flip a bit in the ciphertext body (after the 17-byte header + 4-byte chunk len)
+    <<header::binary-21, rest::binary>> = encrypted
     <<byte, tail::binary>> = rest
     corrupted = <<header::binary, Bitwise.bxor(byte, 0xFF), tail::binary>>
     assert {:error, :authentication_failed} = Encryption.decrypt(corrupted, @key)
@@ -55,6 +55,13 @@ defmodule Peridiod.Cache.EncryptionTest do
   test "decrypt returns error for invalid format" do
     assert {:error, :invalid_format} = Encryption.decrypt("not encrypted", @key)
     assert {:error, :invalid_format} = Encryption.decrypt(<<>>, @key)
+  end
+
+  test "decrypt returns :invalid_format for plaintext that starts with the version byte" do
+    # Without a magic prefix, arbitrary plaintext starting with 0x01 would
+    # false-match the header and surface confusing downstream errors.
+    plaintext_colliding_on_version = <<1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>
+    assert {:error, :invalid_format} = Encryption.decrypt(plaintext_colliding_on_version, @key)
   end
 
   test "each encrypt call produces different ciphertext" do

--- a/test/peridiod/cache/encryption_test.exs
+++ b/test/peridiod/cache/encryption_test.exs
@@ -1,5 +1,5 @@
 defmodule Peridiod.Cache.EncryptionTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Peridiod.Cache.Encryption
 
@@ -108,7 +108,7 @@ defmodule Peridiod.Cache.EncryptionTest do
              Encryption.decrypt_to_tempfile(enc_path, temp_dir, wrong_key)
 
     # Temp file should have been cleaned up
-    refute File.exists?(Path.join(temp_dir, ".tmp_*"))
+    assert Path.wildcard(Path.join(temp_dir, ".tmp_*")) == []
   end
 
   test "decrypt_to_tempfile fails for invalid format" do

--- a/test/peridiod/cache/encryption_test.exs
+++ b/test/peridiod/cache/encryption_test.exs
@@ -1,0 +1,240 @@
+defmodule Peridiod.Cache.EncryptionTest do
+  use ExUnit.Case, async: true
+
+  alias Peridiod.Cache.Encryption
+
+  @key :crypto.strong_rand_bytes(32)
+
+  # ---------------------------------------------------------------------------
+  # One-shot encrypt / decrypt
+  # ---------------------------------------------------------------------------
+
+  test "encrypt/decrypt roundtrip for small content" do
+    plaintext = "hello, world"
+    encrypted = Encryption.encrypt(plaintext, @key)
+    assert is_binary(encrypted)
+    assert encrypted != plaintext
+    assert {:ok, ^plaintext} = Encryption.decrypt(encrypted, @key)
+  end
+
+  test "encrypt/decrypt roundtrip for empty content" do
+    plaintext = ""
+    encrypted = Encryption.encrypt(plaintext, @key)
+    assert {:ok, ^plaintext} = Encryption.decrypt(encrypted, @key)
+  end
+
+  test "encrypt/decrypt roundtrip for exactly one chunk boundary" do
+    plaintext = :crypto.strong_rand_bytes(65_536)
+    encrypted = Encryption.encrypt(plaintext, @key)
+    assert {:ok, ^plaintext} = Encryption.decrypt(encrypted, @key)
+  end
+
+  test "encrypt/decrypt roundtrip for multiple chunks" do
+    plaintext = :crypto.strong_rand_bytes(200_000)
+    encrypted = Encryption.encrypt(plaintext, @key)
+    assert {:ok, ^plaintext} = Encryption.decrypt(encrypted, @key)
+  end
+
+  test "decrypt returns error for wrong key" do
+    plaintext = "secret"
+    encrypted = Encryption.encrypt(plaintext, @key)
+    wrong_key = :crypto.strong_rand_bytes(32)
+    assert {:error, :authentication_failed} = Encryption.decrypt(encrypted, wrong_key)
+  end
+
+  test "decrypt returns error for corrupted ciphertext" do
+    plaintext = "secret data"
+    encrypted = Encryption.encrypt(plaintext, @key)
+    # Flip a bit in the ciphertext body (after the 13-byte header + 4-byte chunk len)
+    <<header::binary-17, rest::binary>> = encrypted
+    <<byte, tail::binary>> = rest
+    corrupted = <<header::binary, Bitwise.bxor(byte, 0xFF), tail::binary>>
+    assert {:error, :authentication_failed} = Encryption.decrypt(corrupted, @key)
+  end
+
+  test "decrypt returns error for invalid format" do
+    assert {:error, :invalid_format} = Encryption.decrypt("not encrypted", @key)
+    assert {:error, :invalid_format} = Encryption.decrypt(<<>>, @key)
+  end
+
+  test "each encrypt call produces different ciphertext" do
+    plaintext = "same plaintext"
+    ct1 = Encryption.encrypt(plaintext, @key)
+    ct2 = Encryption.encrypt(plaintext, @key)
+    # Different random nonces produce different ciphertext
+    assert ct1 != ct2
+    assert {:ok, ^plaintext} = Encryption.decrypt(ct1, @key)
+    assert {:ok, ^plaintext} = Encryption.decrypt(ct2, @key)
+  end
+
+  # ---------------------------------------------------------------------------
+  # File-level encrypt / decrypt
+  # ---------------------------------------------------------------------------
+
+  @tmp "test/workspace/cache/encryption_test"
+
+  setup do
+    File.mkdir_p!(@tmp)
+    on_exit(fn -> File.rm_rf(@tmp) end)
+    :ok
+  end
+
+  test "encrypt_file / decrypt_to_tempfile roundtrip" do
+    plaintext = :crypto.strong_rand_bytes(100_000)
+    plain_path = Path.join(@tmp, "plain")
+    enc_path = Path.join(@tmp, "enc")
+
+    File.write!(plain_path, plaintext)
+    assert :ok = Encryption.encrypt_file(plain_path, enc_path, @key)
+
+    temp_dir = Path.join(@tmp, "tmp")
+    assert {:ok, temp_path} = Encryption.decrypt_to_tempfile(enc_path, temp_dir, @key)
+    assert File.read!(temp_path) == plaintext
+    File.rm(temp_path)
+  end
+
+  test "decrypt_to_tempfile fails for wrong key" do
+    plaintext = "confidential"
+    plain_path = Path.join(@tmp, "plain2")
+    enc_path = Path.join(@tmp, "enc2")
+
+    File.write!(plain_path, plaintext)
+    :ok = Encryption.encrypt_file(plain_path, enc_path, @key)
+
+    wrong_key = :crypto.strong_rand_bytes(32)
+    temp_dir = Path.join(@tmp, "tmp2")
+
+    assert {:error, :authentication_failed} =
+             Encryption.decrypt_to_tempfile(enc_path, temp_dir, wrong_key)
+
+    # Temp file should have been cleaned up
+    refute File.exists?(Path.join(temp_dir, ".tmp_*"))
+  end
+
+  test "decrypt_to_tempfile fails for invalid format" do
+    bad_path = Path.join(@tmp, "bad")
+    File.write!(bad_path, "plaintext, not encrypted")
+
+    temp_dir = Path.join(@tmp, "tmp3")
+    assert {:error, :invalid_format} = Encryption.decrypt_to_tempfile(bad_path, temp_dir, @key)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Streaming decrypt
+  # ---------------------------------------------------------------------------
+
+  test "decrypt_stream yields decrypted chunks and valid eof" do
+    plaintext = :crypto.strong_rand_bytes(150_000)
+    plain_path = Path.join(@tmp, "stream_plain")
+    enc_path = Path.join(@tmp, "stream_enc")
+
+    File.write!(plain_path, plaintext)
+    :ok = Encryption.encrypt_file(plain_path, enc_path, @key)
+
+    # Build a real sig so decrypt_stream can verify it
+    hash = Peridiod.Crypto.hash(enc_path, :sha256)
+    {private_key, public_key} = test_keypair()
+    sig_hex = Peridiod.Crypto.sign(hash, :sha256, private_key)
+    {:ok, sig} = Base.decode16(sig_hex, case: :mixed)
+
+    stream = Encryption.decrypt_stream(enc_path, :sha256, sig, public_key, @key)
+    events = Enum.to_list(stream)
+
+    {stream_events, [eof_event]} = Enum.split_while(events, &match?({:stream, _}, &1))
+    assert {:eof, :valid_signature, _hash} = eof_event
+
+    reassembled =
+      stream_events |> Enum.map(fn {:stream, chunk} -> chunk end) |> IO.iodata_to_binary()
+
+    assert reassembled == plaintext
+  end
+
+  test "decrypt_stream reports invalid_signature on wrong key" do
+    plaintext = "secret"
+    plain_path = Path.join(@tmp, "bad_key_plain")
+    enc_path = Path.join(@tmp, "bad_key_enc")
+
+    File.write!(plain_path, plaintext)
+    :ok = Encryption.encrypt_file(plain_path, enc_path, @key)
+
+    {private_key, public_key} = test_keypair()
+    hash = Peridiod.Crypto.hash(enc_path, :sha256)
+    sig_hex = Peridiod.Crypto.sign(hash, :sha256, private_key)
+    {:ok, sig} = Base.decode16(sig_hex, case: :mixed)
+
+    wrong_key = :crypto.strong_rand_bytes(32)
+    stream = Encryption.decrypt_stream(enc_path, :sha256, sig, public_key, wrong_key)
+    events = Enum.to_list(stream)
+
+    assert Enum.any?(events, &match?({:eof, :invalid_signature, _}, &1))
+  end
+
+  # ---------------------------------------------------------------------------
+  # Format detection
+  # ---------------------------------------------------------------------------
+
+  test "encrypted?/1 returns true for encrypted files" do
+    plain_path = Path.join(@tmp, "detect_plain")
+    enc_path = Path.join(@tmp, "detect_enc")
+    File.write!(plain_path, "hello")
+    :ok = Encryption.encrypt_file(plain_path, enc_path, @key)
+    assert Encryption.encrypted?(enc_path)
+  end
+
+  test "encrypted?/1 returns false for plaintext files" do
+    plain_path = Path.join(@tmp, "detect_plain2")
+    File.write!(plain_path, "hello")
+    refute Encryption.encrypted?(plain_path)
+  end
+
+  test "encrypted?/1 returns false for missing files" do
+    refute Encryption.encrypted?(Path.join(@tmp, "nonexistent"))
+  end
+
+  # ---------------------------------------------------------------------------
+  # DEK lifecycle
+  # ---------------------------------------------------------------------------
+
+  test "load_or_create_dek generates a DEK on first call" do
+    dek_dir = Path.join(@tmp, "dek_test")
+    {private_key, public_key} = test_keypair()
+
+    assert {:ok, dek} = Encryption.load_or_create_dek(dek_dir, private_key, public_key)
+    assert byte_size(dek) == 32
+    assert File.exists?(Path.join(dek_dir, ".dek"))
+    assert File.exists?(Path.join(dek_dir, ".dek.sig"))
+  end
+
+  test "load_or_create_dek returns same DEK on subsequent calls" do
+    dek_dir = Path.join(@tmp, "dek_test2")
+    {private_key, public_key} = test_keypair()
+
+    {:ok, dek1} = Encryption.load_or_create_dek(dek_dir, private_key, public_key)
+    {:ok, dek2} = Encryption.load_or_create_dek(dek_dir, private_key, public_key)
+    assert dek1 == dek2
+  end
+
+  test "load_or_create_dek fails when DEK signature is invalid" do
+    dek_dir = Path.join(@tmp, "dek_tamper")
+    {private_key, public_key} = test_keypair()
+
+    {:ok, _dek} = Encryption.load_or_create_dek(dek_dir, private_key, public_key)
+    # Overwrite DEK file with different bytes (signature becomes invalid)
+    File.write!(Path.join(dek_dir, ".dek"), :crypto.strong_rand_bytes(32))
+
+    assert {:error, :dek_signature_invalid} =
+             Encryption.load_or_create_dek(dek_dir, private_key, public_key)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp test_keypair do
+    private_key_pem = File.read!("test/fixtures/device/device-private-key.pem")
+    private_key = X509.PrivateKey.from_pem!(private_key_pem)
+    cert_pem = File.read!("test/fixtures/device/device-certificate.pem")
+    public_key = X509.Certificate.from_pem!(cert_pem) |> X509.Certificate.public_key()
+    {private_key, public_key}
+  end
+end

--- a/test/peridiod/cache_test.exs
+++ b/test/peridiod/cache_test.exs
@@ -86,9 +86,8 @@ defmodule Peridiod.CacheTest do
 
     :ok = Cache.write(cache_pid, file, content)
     :ok = Cache.ln_s(cache_pid, file, link)
-    # Verify the symlink was created (it points to the possibly-encrypted file)
-    assert File.exists?(Path.join([cache_dir, link]))
-    # Content is still accessible via the original cache file
+    link_path = Path.join([cache_dir, link])
+    assert {:ok, %File.Stat{type: :symlink}} = File.lstat(link_path)
     assert {:ok, ^content} = Cache.read(cache_pid, file)
   end
 

--- a/test/peridiod/cache_test.exs
+++ b/test/peridiod/cache_test.exs
@@ -86,7 +86,10 @@ defmodule Peridiod.CacheTest do
 
     :ok = Cache.write(cache_pid, file, content)
     :ok = Cache.ln_s(cache_pid, file, link)
-    assert {:ok, ^content} = File.read(Path.join([cache_dir, link]))
+    # Verify the symlink was created (it points to the possibly-encrypted file)
+    assert File.exists?(Path.join([cache_dir, link]))
+    # Content is still accessible via the original cache file
+    assert {:ok, ^content} = Cache.read(cache_pid, file)
   end
 
   test "rm", %{cache_pid: cache_pid, test: name} do

--- a/test/peridiod/plan/step_test.exs
+++ b/test/peridiod/plan/step_test.exs
@@ -6,6 +6,19 @@ defmodule Peridiod.Plan.StepTest do
   alias Peridiod.Binary.Installer
   alias Peridiod.Plan.Step
 
+  # Path-only test installer — exercises the Cache.decrypt_to_tempfile code path.
+  defmodule PathOnlyInstaller do
+    use Peridiod.Binary.Installer
+    def execution_model, do: :parallel
+    def interfaces, do: [:path]
+
+    def path_install(_meta, path, _opts) do
+      if File.regular?(path),
+        do: {:stop, :normal, nil},
+        else: {:error, "file not found: #{path}", nil}
+    end
+  end
+
   describe "binary cache" do
     setup :start_cache
     setup :load_release_metadata_from_manifest
@@ -136,6 +149,38 @@ defmodule Peridiod.Plan.StepTest do
 
       assert_receive {Step, ^step_pid, :complete}
       assert Binary.installed?(cache_pid, binary_metadata)
+    end
+
+    test "complete cache path-only installer", %{
+      cache_pid: cache_pid,
+      kv_pid: kv_pid,
+      cache_dir: cache_dir,
+      release_metadata: %{bundle: %{binaries: binaries}}
+    } do
+      binary_metadata = List.first(binaries)
+      test_file = Peridiod.TestFixtures.binary_fixture_path() |> Path.join("1M.bin")
+      content = File.read!(test_file)
+      cache_file = Binary.cache_file(binary_metadata)
+      :ok = Cache.write(cache_pid, cache_file, content)
+      :ok = Binary.stamp_cached(cache_pid, binary_metadata)
+
+      step_opts = %{
+        binary_metadata: binary_metadata,
+        cache_pid: cache_pid,
+        kv_pid: kv_pid,
+        callback: self(),
+        installer_mod: PathOnlyInstaller,
+        installer_opts: %{},
+        source: :cache
+      }
+
+      {:ok, step_pid} = Step.start_link({Step.BinaryInstall, step_opts})
+      Step.execute(step_pid)
+
+      assert_receive {Step, ^step_pid, :complete}
+      assert Binary.installed?(cache_pid, binary_metadata)
+      # All decrypted temp files must be cleaned up after install
+      assert Path.wildcard(Path.join([cache_dir, ".tmp", ".tmp_*"])) == []
     end
   end
 

--- a/test/peridiod/plan/step_test.exs
+++ b/test/peridiod/plan/step_test.exs
@@ -182,6 +182,49 @@ defmodule Peridiod.Plan.StepTest do
       # All decrypted temp files must be cleaned up after install
       assert Path.wildcard(Path.join([cache_dir, ".tmp", ".tmp_*"])) == []
     end
+
+    test "path-only installer clears stale pre-encryption plaintext from cache", %{
+      cache_pid: cache_pid,
+      kv_pid: kv_pid,
+      release_metadata: %{bundle: %{binaries: binaries}}
+    } do
+      binary_metadata = List.first(binaries)
+      test_file = Peridiod.TestFixtures.binary_fixture_path() |> Path.join("1M.bin")
+      content = File.read!(test_file)
+
+      # Simulate the upgrade path: a cached binary written before encryption was
+      # enabled. Plaintext on disk with a signature over the plaintext bytes.
+      cache_file = Binary.cache_file(binary_metadata)
+      abs_path = Cache.abs_path(cache_pid, cache_file)
+      File.mkdir_p!(Path.dirname(abs_path))
+      File.write!(abs_path, content)
+
+      %{private_key: private_key} = :sys.get_state(cache_pid)
+      hash = Peridiod.Crypto.hash(abs_path, :sha256)
+      sig_hex = Peridiod.Crypto.sign(hash, :sha256, private_key)
+      File.write!(abs_path <> ".sig", sig_hex)
+
+      :ok = Binary.stamp_cached(cache_pid, binary_metadata)
+      assert Binary.cached?(cache_pid, binary_metadata)
+
+      step_opts = %{
+        binary_metadata: binary_metadata,
+        cache_pid: cache_pid,
+        kv_pid: kv_pid,
+        callback: self(),
+        installer_mod: PathOnlyInstaller,
+        installer_opts: %{},
+        source: :cache
+      }
+
+      {:ok, step_pid} = Step.start_link({Step.BinaryInstall, step_opts})
+      Step.execute(step_pid)
+
+      assert_receive {Step, ^step_pid, {:error, :invalid_format}}
+      # Stale plaintext entry must be removed so next attempt re-downloads
+      # instead of looping on the same decrypt failure.
+      refute Binary.cached?(cache_pid, binary_metadata)
+    end
   end
 
   describe "system reboot" do


### PR DESCRIPTION
## Summary

- Add AES-256-GCM at-rest encryption to the `Peridiod.Cache` GenServer (SOC2 C1 Confidentiality, ENG-1710)
- Introduce a per-device Data Encryption Key (DEK) stored at `cache_dir/.dek`, signed by the device's existing asymmetric key so tampering is detected on startup
- Files are stored in a chunked encrypted format (4-byte `PDC1` magic + version + 64 KiB chunks with independent GCM tags) enabling streaming decrypt without loading entire files into memory
- `Cache.read/2`, `Cache.write/3`, `Cache.read_stream/2`, `write_stream_finish`, and `write_stream_finish_local` all encrypt/decrypt transparently — callers are unaffected
- Add `Cache.decrypt_to_tempfile/2` for path-based binary installers (e.g. `deb`) that need a plaintext file path; streaming installers continue to use `Cache.read_stream` unchanged
- `Cache.init/1` warns at startup when `cache_dir` permissions are not `0700` and sets `0700` on newly created directories
- Opt-out available via `"cache_encryption_enabled": false` in `peridio-config.json`

## Behavior change beyond encryption

The `:cache` source for stream-capable binary installers previously routed through `Downloader.Supervisor.start_child` with a synthetic `file://` URL — i.e. the HTTP downloader retry/error machinery was reused for local cache reads. This PR splits the `:cache` path into two branches in `Plan.Step.BinaryInstall.validate_source_interface/3`:

- **Path-only installers** (`deb`, `opkg`, `rpm`, `swupdate`) go through `Cache.decrypt_to_tempfile/2` and receive a plaintext temp file path.
- **Stream-capable installers** (`fwup`, `avocado-os`, `avocado-ext`) go through `Cache.read_stream/2` directly (via a `Task`), bypassing the downloader supervisor.

Decryption is correct in either case; this is a change in *how* bytes are delivered, not *whether*. Flagged for future readers since the routing change is orthogonal to the encryption work.

## Threat model

See the moduledoc on `Peridiod.Cache.Encryption` for what this scheme does and does not protect against. Short version: compliance + tamper detection + permission-based separation + scoped exfiltration resistance. Not confidentiality against an attacker with filesystem read access to `.dek`.

## Test plan

- [x] `mix test` passes (219 tests, 0 failures)
- [x] `mix test test/peridiod/cache/encryption_test.exs` — unit tests for `Cache.Encryption`: roundtrip, wrong key, corruption, streaming, DEK lifecycle, plaintext-collision regression
- [x] `mix test test/peridiod/cache_test.exs` — existing cache tests pass with encryption enabled
- [x] `mix test test/peridiod/plan/step_test.exs` — BinaryInstall step tests pass (path, stream, and pre-encryption-plaintext migration regression)
- [x] `mix test test/peridiod/bundle/server_test.exs` — bundle install/cache tests pass
- [ ] Verify encrypted files appear as binary (not readable JSON) in `cache_dir` after a bundle install
- [ ] Verify `cache_encryption_enabled: false` in config disables encryption and files remain plaintext