### PR TITLE
[SOC2] Enforce verify_peer — prevent verify_none in production

### DIFF
--- a/lib/peridiod.ex
+++ b/lib/peridiod.ex
@@ -9,7 +9,7 @@ defmodule Peridiod do
     @env == :test
   end
 
-  @spec env_prod? :: boolean()
+  @spec env_prod?() :: boolean()
   def env_prod?() do
     @env == :prod
   end

--- a/lib/peridiod.ex
+++ b/lib/peridiod.ex
@@ -9,6 +9,11 @@ defmodule Peridiod do
     @env == :test
   end
 
+  @spec env_prod? :: boolean()
+  def env_prod?() do
+    @env == :prod
+  end
+
   @spec config :: Peridiod.Config.t()
   def config() do
     application_config = Application.get_all_env(:peridiod)

--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -236,6 +236,19 @@ defmodule Peridiod.Config do
         value when is_atom(value) -> value
       end
 
+    verify =
+      if verify == :verify_none and Peridiod.env_prod?() do
+        Logger.warning(
+          "[Config] device_api_verify is set to :verify_none, " <>
+            "but this is not allowed in production. Forcing :verify_peer. " <>
+            "Set \"verify\": true in peridio-config.json to resolve this warning."
+        )
+
+        :verify_peer
+      else
+        verify
+      end
+
     network_monitor = Cloud.NetworkMonitor.config(config.network_monitor)
     trusted_signing_keys = Map.get(config, :trusted_signing_keys) |> load_trusted_signing_keys()
 

--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -236,18 +236,7 @@ defmodule Peridiod.Config do
         value when is_atom(value) -> value
       end
 
-    verify =
-      if verify == :verify_none and Peridiod.env_prod?() do
-        Logger.warning(
-          "[Config] device_api_verify is set to :verify_none, " <>
-            "but this is not allowed in production. Forcing :verify_peer. " <>
-            "Set \"verify\": true in peridio-config.json to resolve this warning."
-        )
-
-        :verify_peer
-      else
-        verify
-      end
+    verify = resolve_verify(verify, Peridiod.env_prod?())
 
     network_monitor = Cloud.NetworkMonitor.config(config.network_monitor)
     trusted_signing_keys = Map.get(config, :trusted_signing_keys) |> load_trusted_signing_keys()
@@ -394,6 +383,18 @@ defmodule Peridiod.Config do
 
     %{base | socket: socket, ssl: ssl}
   end
+
+  def resolve_verify(:verify_none, true = _env_prod?) do
+    Logger.warning(
+      "[Config] device_api_verify is set to :verify_none, " <>
+        "but this is not allowed in production. Forcing :verify_peer. " <>
+        "Set device_api.verify to true in peridio-config.json to resolve this warning."
+    )
+
+    :verify_peer
+  end
+
+  def resolve_verify(verify, _env_prod?), do: verify
 
   def load_trusted_signing_keys(trusted_signing_keys) do
     Enum.reduce(trusted_signing_keys, [], fn key, signing_keys ->

--- a/test/fixtures/peridio-verify-none.json
+++ b/test/fixtures/peridio-verify-none.json
@@ -1,0 +1,20 @@
+{
+    "version": 1,
+    "device_api": {
+      "certificate_path": "test/fixtures/peridio-cert.pem",
+      "url": "device.staging.cremini.peridio.com",
+      "verify": false
+    },
+    "fwup": {
+      "devpath": "/dev/mmcblk0",
+      "public_keys": []
+    },
+    "remote_shell": true,
+    "node": {
+      "key_pair_source": "file",
+      "key_pair_config": {
+        "private_key_path": "test/fixtures/device/device-private-key.pem",
+        "certificate_path": "test/fixtures/device/device-certificate.pem"
+      }
+    }
+  }

--- a/test/peridiod/config_test.exs
+++ b/test/peridiod/config_test.exs
@@ -1,6 +1,8 @@
 defmodule Peridiod.ConfigTest do
   use ExUnit.Case
 
+  import ExUnit.CaptureLog
+
   defp build_config do
     Application.get_all_env(:peridiod)
     |> then(&struct(Peridiod.Config, &1))
@@ -27,8 +29,10 @@ defmodule Peridiod.ConfigTest do
     end
 
     test "verify: true resolves to :verify_peer" do
-      config = build_config()
-      assert config.ssl[:verify] == :verify_peer
+      with_config_file("test/fixtures/peridio.json", fn ->
+        config = build_config()
+        assert config.ssl[:verify] == :verify_peer
+      end)
     end
 
     test "verify: false resolves to :verify_none in non-prod env" do
@@ -36,6 +40,27 @@ defmodule Peridiod.ConfigTest do
         config = build_config()
         assert config.ssl[:verify] == :verify_none
       end)
+    end
+  end
+
+  describe "resolve_verify/2" do
+    test "returns :verify_peer unchanged" do
+      assert Peridiod.Config.resolve_verify(:verify_peer, true) == :verify_peer
+      assert Peridiod.Config.resolve_verify(:verify_peer, false) == :verify_peer
+    end
+
+    test "returns :verify_none when not in production" do
+      assert Peridiod.Config.resolve_verify(:verify_none, false) == :verify_none
+    end
+
+    test "forces :verify_peer and warns when :verify_none in production" do
+      log =
+        capture_log(fn ->
+          assert Peridiod.Config.resolve_verify(:verify_none, true) == :verify_peer
+        end)
+
+      assert log =~ "device_api_verify is set to :verify_none"
+      assert log =~ "Forcing :verify_peer"
     end
   end
 end

--- a/test/peridiod/config_test.exs
+++ b/test/peridiod/config_test.exs
@@ -1,0 +1,41 @@
+defmodule Peridiod.ConfigTest do
+  use ExUnit.Case
+
+  defp build_config do
+    Application.get_all_env(:peridiod)
+    |> then(&struct(Peridiod.Config, &1))
+    |> Peridiod.Config.new()
+  end
+
+  defp with_config_file(path, fun) do
+    original = System.get_env("PERIDIO_CONFIG_FILE")
+    System.put_env("PERIDIO_CONFIG_FILE", path)
+
+    try do
+      fun.()
+    after
+      case original do
+        nil -> System.delete_env("PERIDIO_CONFIG_FILE")
+        val -> System.put_env("PERIDIO_CONFIG_FILE", val)
+      end
+    end
+  end
+
+  describe "device_api_verify" do
+    test "struct default is :verify_peer" do
+      assert %Peridiod.Config{}.device_api_verify == :verify_peer
+    end
+
+    test "verify: true resolves to :verify_peer" do
+      config = build_config()
+      assert config.ssl[:verify] == :verify_peer
+    end
+
+    test "verify: false resolves to :verify_none in non-prod env" do
+      with_config_file("test/fixtures/peridio-verify-none.json", fn ->
+        config = build_config()
+        assert config.ssl[:verify] == :verify_none
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- In production builds, `device_api_verify: :verify_none` (set via `peridio-config.json` `"verify": false`) is now overridden back to `:verify_peer` with a `Logger.warning`, protecting devices from MITM attacks caused by a misconfigured or malicious config file
- Adds `Peridiod.env_prod?/0` alongside the existing `env_test?/0`, using the same compile-time `@env Mix.env()` attribute — the value is baked in at compile time and works correctly in releases
- Adds `test/peridiod/config_test.exs` covering the struct default, `verify: true → :verify_peer`, and `verify: false → :verify_none` (non-prod only)

Closes ENG-1708.

## Test plan

- [ ] `mix compile` — no warnings or errors
- [ ] `mix test test/peridiod/config_test.exs` — 3 tests pass
- [ ] `mix test` — full suite passes (187 tests, 0 failures)
- [ ] Verify that a production release compiled with `MIX_ENV=prod` logs the warning and forces `:verify_peer` when `"verify": false` is set in `peridio-config.json`