### PR TITLE
[SOC2] Add post-download checksum verification in binary downloader

### DIFF
--- a/lib/peridiod/binary/downloader.ex
+++ b/lib/peridiod/binary/downloader.ex
@@ -137,13 +137,19 @@ defmodule Peridiod.Binary.Downloader do
 
   @spec start_link(
           String.t(),
-          String.t() | URI.t(),
+          URI.t(),
           event_handler_fun(),
           RetryConfig.t(),
           VerifyConfig.t()
         ) ::
           GenServer.on_start()
-  def start_link(id, uri, fun, %RetryConfig{} = retry_args, %VerifyConfig{} = verify_config)
+  def start_link(
+        id,
+        %URI{} = uri,
+        fun,
+        %RetryConfig{} = retry_args,
+        %VerifyConfig{} = verify_config
+      )
       when is_function(fun, 1) do
     GenServer.start_link(__MODULE__, [id, uri, fun, retry_args, verify_config])
   end

--- a/lib/peridiod/binary/downloader.ex
+++ b/lib/peridiod/binary/downloader.ex
@@ -208,9 +208,7 @@ defmodule Peridiod.Binary.Downloader do
     timer = Process.send_after(self(), :max_timeout, retry_args.max_timeout)
     Logger.info("[Stream Downloader #{id}] Started with integrity verification")
 
-    hash_state =
-      if verify_config.expected_hash, do: :crypto.hash_init(:sha256), else: nil
-
+    # hash_state is initialized by reset/1 based on verify_config
     state =
       reset(%Downloader{
         id: id,
@@ -218,8 +216,7 @@ defmodule Peridiod.Binary.Downloader do
         retry_args: retry_args,
         max_timeout: timer,
         uri: uri,
-        verify_config: verify_config,
-        hash_state: hash_state
+        verify_config: verify_config
       })
 
     send(self(), :resume)

--- a/lib/peridiod/binary/downloader.ex
+++ b/lib/peridiod/binary/downloader.ex
@@ -262,12 +262,17 @@ defmodule Peridiod.Binary.Downloader do
       "[Stream Downloader #{id}] Started with resume from #{existing_size} bytes and integrity verification"
     )
 
-    if verify_config.expected_hash do
-      Logger.warning(
-        "[Stream Downloader #{id}] Hash verification skipped for resumed download — " <>
-          "only bytes from resume point are available. Size verification still applies."
-      )
-    end
+    hash_state =
+      if verify_config.expected_hash && existing_size > 0 do
+        Logger.warning(
+          "[Stream Downloader #{id}] Hash verification skipped for partial resume — " <>
+            "only bytes from resume point are available. Size verification still applies."
+        )
+
+        nil
+      else
+        if verify_config.expected_hash, do: :crypto.hash_init(:sha256), else: nil
+      end
 
     state = %Downloader{
       id: id,
@@ -280,7 +285,7 @@ defmodule Peridiod.Binary.Downloader do
       retry_number: 0,
       content_length: 0,
       verify_config: verify_config,
-      hash_state: nil
+      hash_state: hash_state
     }
 
     send(self(), :resume)
@@ -565,12 +570,19 @@ defmodule Peridiod.Binary.Downloader do
   end
 
   defp reset(%Downloader{} = state) do
+    hash_state =
+      case state.verify_config do
+        %VerifyConfig{expected_hash: hash} when not is_nil(hash) -> :crypto.hash_init(:sha256)
+        _ -> nil
+      end
+
     %Downloader{
       state
       | retry_number: 0,
         downloaded_length: 0,
         initial_downloaded_length: 0,
-        content_length: 0
+        content_length: 0,
+        hash_state: hash_state
     }
   end
 

--- a/lib/peridiod/binary/downloader.ex
+++ b/lib/peridiod/binary/downloader.ex
@@ -20,7 +20,8 @@ defmodule Peridiod.Binary.Downloader do
   alias Peridiod.Binary.{
     Downloader,
     Downloader.RetryConfig,
-    Downloader.TimeoutCalculation
+    Downloader.TimeoutCalculation,
+    Downloader.VerifyConfig
   }
 
   alias Peridiod.LogSanitizer
@@ -42,7 +43,9 @@ defmodule Peridiod.Binary.Downloader do
             max_timeout: nil,
             retry_timeout: nil,
             worst_case_timeout: nil,
-            worst_case_timeout_remaining_ms: nil
+            worst_case_timeout_remaining_ms: nil,
+            verify_config: nil,
+            hash_state: nil
 
   @type handler_event :: {:stream, binary()} | {:error, any()} | :complete
   @type event_handler_fun :: (handler_event -> any())
@@ -67,7 +70,9 @@ defmodule Peridiod.Binary.Downloader do
           max_timeout: timer(),
           retry_timeout: nil | timer(),
           worst_case_timeout: nil | timer(),
-          worst_case_timeout_remaining_ms: nil | non_neg_integer()
+          worst_case_timeout_remaining_ms: nil | non_neg_integer(),
+          verify_config: nil | VerifyConfig.t(),
+          hash_state: nil | :crypto.hash_state()
         }
 
   @type initialized_download :: %Downloader{
@@ -114,10 +119,33 @@ defmodule Peridiod.Binary.Downloader do
     }
   end
 
+  def child_spec(id, uri, fun, %RetryConfig{} = retry_args, %VerifyConfig{} = verify_config) do
+    %{
+      id: Module.concat(__MODULE__, id),
+      start: {__MODULE__, :start_link, [id, uri, fun, retry_args, verify_config]},
+      shutdown: 5000,
+      type: :worker,
+      restart: :transient
+    }
+  end
+
   @spec start_link(String.t(), String.t() | URI.t(), event_handler_fun(), RetryConfig.t()) ::
           GenServer.on_start()
   def start_link(id, uri, fun, %RetryConfig{} = retry_args) when is_function(fun, 1) do
     GenServer.start_link(__MODULE__, [id, uri, fun, retry_args])
+  end
+
+  @spec start_link(
+          String.t(),
+          String.t() | URI.t(),
+          event_handler_fun(),
+          RetryConfig.t(),
+          VerifyConfig.t()
+        ) ::
+          GenServer.on_start()
+  def start_link(id, uri, fun, %RetryConfig{} = retry_args, %VerifyConfig{} = verify_config)
+      when is_function(fun, 1) do
+    GenServer.start_link(__MODULE__, [id, uri, fun, retry_args, verify_config])
   end
 
   @spec start_link_with_resume(
@@ -131,6 +159,27 @@ defmodule Peridiod.Binary.Downloader do
   def start_link_with_resume(id, %URI{} = uri, fun, %RetryConfig{} = retry_args, existing_size)
       when is_function(fun, 1) do
     GenServer.start_link(__MODULE__, [id, uri, fun, retry_args, existing_size])
+  end
+
+  @spec start_link_with_resume(
+          String.t(),
+          URI.t(),
+          event_handler_fun(),
+          RetryConfig.t(),
+          non_neg_integer(),
+          VerifyConfig.t()
+        ) ::
+          GenServer.on_start()
+  def start_link_with_resume(
+        id,
+        %URI{} = uri,
+        fun,
+        %RetryConfig{} = retry_args,
+        existing_size,
+        %VerifyConfig{} = verify_config
+      )
+      when is_function(fun, 1) do
+    GenServer.start_link(__MODULE__, [id, uri, fun, retry_args, existing_size, verify_config])
   end
 
   def stop(pid) do
@@ -155,7 +204,30 @@ defmodule Peridiod.Binary.Downloader do
     {:ok, state}
   end
 
-  def init([id, %URI{} = uri, fun, %RetryConfig{} = retry_args, existing_size]) do
+  def init([id, %URI{} = uri, fun, %RetryConfig{} = retry_args, %VerifyConfig{} = verify_config]) do
+    timer = Process.send_after(self(), :max_timeout, retry_args.max_timeout)
+    Logger.info("[Stream Downloader #{id}] Started with integrity verification")
+
+    hash_state =
+      if verify_config.expected_hash, do: :crypto.hash_init(:sha256), else: nil
+
+    state =
+      reset(%Downloader{
+        id: id,
+        handler_fun: fun,
+        retry_args: retry_args,
+        max_timeout: timer,
+        uri: uri,
+        verify_config: verify_config,
+        hash_state: hash_state
+      })
+
+    send(self(), :resume)
+    {:ok, state}
+  end
+
+  def init([id, %URI{} = uri, fun, %RetryConfig{} = retry_args, existing_size])
+      when is_integer(existing_size) do
     timer = Process.send_after(self(), :max_timeout, retry_args.max_timeout)
     Logger.info("[Stream Downloader #{id}] Started with resume from #{existing_size} bytes")
 
@@ -169,6 +241,46 @@ defmodule Peridiod.Binary.Downloader do
       initial_downloaded_length: existing_size,
       retry_number: 0,
       content_length: 0
+    }
+
+    send(self(), :resume)
+    {:ok, state}
+  end
+
+  def init([
+        id,
+        %URI{} = uri,
+        fun,
+        %RetryConfig{} = retry_args,
+        existing_size,
+        %VerifyConfig{} = verify_config
+      ])
+      when is_integer(existing_size) do
+    timer = Process.send_after(self(), :max_timeout, retry_args.max_timeout)
+
+    Logger.info(
+      "[Stream Downloader #{id}] Started with resume from #{existing_size} bytes and integrity verification"
+    )
+
+    if verify_config.expected_hash do
+      Logger.warning(
+        "[Stream Downloader #{id}] Hash verification skipped for resumed download — " <>
+          "only bytes from resume point are available. Size verification still applies."
+      )
+    end
+
+    state = %Downloader{
+      id: id,
+      handler_fun: fun,
+      retry_args: retry_args,
+      max_timeout: timer,
+      uri: uri,
+      downloaded_length: existing_size,
+      initial_downloaded_length: existing_size,
+      retry_number: 0,
+      content_length: 0,
+      verify_config: verify_config,
+      hash_state: nil
     }
 
     send(self(), :resume)
@@ -297,8 +409,7 @@ defmodule Peridiod.Binary.Downloader do
        when downloaded != 0 and content_length > 0 and downloaded - initial >= content_length do
     # For range requests: downloaded_length - initial_downloaded_length should equal content_length
     # For full downloads: downloaded_length should equal content_length (initial is 0)
-    _ = state.handler_fun.(:complete)
-    {:stop, :normal, state}
+    verify_and_complete(state)
   end
 
   defp handle_responses([], %Downloader{} = state) do
@@ -400,7 +511,8 @@ defmodule Peridiod.Binary.Downloader do
         %Downloader{request_ref: request_ref, downloaded_length: downloaded} = state
       ) do
     _ = state.handler_fun.({:stream, data})
-    %Downloader{state | downloaded_length: downloaded + byte_size(data)}
+    hash_state = if state.hash_state, do: :crypto.hash_update(state.hash_state, data), else: nil
+    %Downloader{state | downloaded_length: downloaded + byte_size(data), hash_state: hash_state}
   end
 
   def handle_response({:done, request_ref}, %Downloader{request_ref: request_ref} = state) do
@@ -410,6 +522,46 @@ defmodule Peridiod.Binary.Downloader do
   # ignore other messages when redirecting
   def handle_response(_, %Downloader{status: nil} = state) do
     state
+  end
+
+  defp verify_and_complete(%Downloader{verify_config: nil} = state) do
+    _ = state.handler_fun.(:complete)
+    {:stop, :normal, state}
+  end
+
+  defp verify_and_complete(%Downloader{verify_config: %VerifyConfig{} = vc} = state) do
+    with :ok <- verify_size(state, vc),
+         :ok <- verify_hash(state, vc) do
+      _ = state.handler_fun.(:complete)
+      {:stop, :normal, state}
+    else
+      {:error, reason} ->
+        Logger.error(
+          "[Stream Downloader #{state.id}] Integrity verification failed: #{inspect(reason)}"
+        )
+
+        _ = state.handler_fun.({:error, reason})
+        {:stop, :normal, state}
+    end
+  end
+
+  defp verify_size(_state, %VerifyConfig{expected_size: nil}), do: :ok
+
+  defp verify_size(%Downloader{downloaded_length: actual}, %VerifyConfig{expected_size: expected}) do
+    if actual == expected,
+      do: :ok,
+      else: {:error, {:size_mismatch, expected: expected, actual: actual}}
+  end
+
+  defp verify_hash(%Downloader{hash_state: nil}, _vc), do: :ok
+  defp verify_hash(_state, %VerifyConfig{expected_hash: nil}), do: :ok
+
+  defp verify_hash(%Downloader{hash_state: hash_state}, %VerifyConfig{expected_hash: expected}) do
+    actual = :crypto.hash_final(hash_state)
+
+    if actual == expected,
+      do: :ok,
+      else: {:error, {:checksum_mismatch, expected: expected, actual: actual}}
   end
 
   defp reset(%Downloader{} = state) do

--- a/lib/peridiod/binary/downloader/supervisor.ex
+++ b/lib/peridiod/binary/downloader/supervisor.ex
@@ -21,13 +21,19 @@ defmodule Peridiod.Binary.Downloader.Supervisor do
   def start_child(id, uri, fun, opts) when is_list(opts) do
     parsed_uri = if is_binary(uri), do: URI.parse(uri), else: uri
     retry_config = Keyword.get(opts, :retry_config, %RetryConfig{})
-    verify_config = Keyword.get(opts, :verify_config)
 
     child_spec =
-      if verify_config do
-        Downloader.child_spec(id, parsed_uri, fun, retry_config, verify_config)
-      else
-        Downloader.child_spec(id, parsed_uri, fun, retry_config)
+      case Keyword.get(opts, :verify_config) do
+        nil ->
+          Downloader.child_spec(id, parsed_uri, fun, retry_config)
+
+        %Downloader.VerifyConfig{} = verify_config ->
+          Downloader.child_spec(id, parsed_uri, fun, retry_config, verify_config)
+
+        invalid ->
+          raise ArgumentError,
+                "expected :verify_config to be nil or %Peridiod.Binary.Downloader.VerifyConfig{}, " <>
+                  "got: #{inspect(invalid)}"
       end
 
     DynamicSupervisor.start_child(__MODULE__, child_spec)

--- a/lib/peridiod/binary/downloader/supervisor.ex
+++ b/lib/peridiod/binary/downloader/supervisor.ex
@@ -18,6 +18,21 @@ defmodule Peridiod.Binary.Downloader.Supervisor do
     DynamicSupervisor.start_child(__MODULE__, child_spec)
   end
 
+  def start_child(id, uri, fun, opts) when is_list(opts) do
+    parsed_uri = if is_binary(uri), do: URI.parse(uri), else: uri
+    retry_config = Keyword.get(opts, :retry_config, %RetryConfig{})
+    verify_config = Keyword.get(opts, :verify_config)
+
+    child_spec =
+      if verify_config do
+        Downloader.child_spec(id, parsed_uri, fun, retry_config, verify_config)
+      else
+        Downloader.child_spec(id, parsed_uri, fun, retry_config)
+      end
+
+    DynamicSupervisor.start_child(__MODULE__, child_spec)
+  end
+
   @impl true
   def init(_init_arg) do
     DynamicSupervisor.init(strategy: :one_for_one)

--- a/lib/peridiod/binary/downloader/verify_config.ex
+++ b/lib/peridiod/binary/downloader/verify_config.ex
@@ -6,9 +6,11 @@ defmodule Peridiod.Binary.Downloader.VerifyConfig do
   download and verify it (and optionally the file size) on completion.
   Any field set to `nil` skips that verification.
 
-  Note: hash verification is skipped for resumed downloads because the
-  Downloader only sees bytes from the resume point onward. Size verification
-  still works for resumed downloads since `downloaded_length` tracks the total.
+  Note: hash verification is skipped only for partial resumed downloads where
+  bytes already exist locally (`existing_size > 0`), because the Downloader
+  only sees bytes from the resume point onward. A resume from byte 0 is treated
+  as a full download and hash verification applies normally. Size verification
+  works for all downloads since `downloaded_length` tracks the running total.
   """
 
   defstruct expected_hash: nil,

--- a/lib/peridiod/binary/downloader/verify_config.ex
+++ b/lib/peridiod/binary/downloader/verify_config.ex
@@ -1,0 +1,21 @@
+defmodule Peridiod.Binary.Downloader.VerifyConfig do
+  @moduledoc """
+  Optional integrity verification configuration for the Downloader.
+
+  When provided to the Downloader, it will compute a SHA-256 hash during
+  download and verify it (and optionally the file size) on completion.
+  Any field set to `nil` skips that verification.
+
+  Note: hash verification is skipped for resumed downloads because the
+  Downloader only sees bytes from the resume point onward. Size verification
+  still works for resumed downloads since `downloaded_length` tracks the total.
+  """
+
+  defstruct expected_hash: nil,
+            expected_size: nil
+
+  @type t :: %__MODULE__{
+          expected_hash: binary() | nil,
+          expected_size: non_neg_integer() | nil
+        }
+end

--- a/lib/peridiod/distribution/server.ex
+++ b/lib/peridiod/distribution/server.ex
@@ -245,6 +245,25 @@ defmodule Peridiod.Distribution.Server do
     {:noreply, reset_update_state(state)}
   end
 
+  def handle_info({:download, {:error, {:checksum_mismatch, details}}}, state) do
+    Logger.error(
+      "[Distributions] Download integrity check failed: SHA-256 mismatch. " <>
+        "Expected: #{Base.encode16(details[:expected], case: :lower)}, " <>
+        "Got: #{Base.encode16(details[:actual], case: :lower)} - Update aborted."
+    )
+
+    {:noreply, reset_update_state(state)}
+  end
+
+  def handle_info({:download, {:error, {:size_mismatch, details}}}, state) do
+    Logger.error(
+      "[Distributions] Download integrity check failed: size mismatch. " <>
+        "Expected: #{details[:expected]} bytes, Got: #{details[:actual]} bytes - Update aborted."
+    )
+
+    {:noreply, reset_update_state(state)}
+  end
+
   def handle_info({:download, {:error, reason}}, state) do
     Logger.warning(
       "[Distributions] Transient HTTP download error (will retry): #{inspect(reason)}"

--- a/lib/peridiod/distribution/server.ex
+++ b/lib/peridiod/distribution/server.ex
@@ -245,25 +245,6 @@ defmodule Peridiod.Distribution.Server do
     {:noreply, reset_update_state(state)}
   end
 
-  def handle_info({:download, {:error, {:checksum_mismatch, details}}}, state) do
-    Logger.error(
-      "[Distributions] Download integrity check failed: SHA-256 mismatch. " <>
-        "Expected: #{Base.encode16(details[:expected], case: :lower)}, " <>
-        "Got: #{Base.encode16(details[:actual], case: :lower)} - Update aborted."
-    )
-
-    {:noreply, reset_update_state(state)}
-  end
-
-  def handle_info({:download, {:error, {:size_mismatch, details}}}, state) do
-    Logger.error(
-      "[Distributions] Download integrity check failed: size mismatch. " <>
-        "Expected: #{details[:expected]} bytes, Got: #{details[:actual]} bytes - Update aborted."
-    )
-
-    {:noreply, reset_update_state(state)}
-  end
-
   def handle_info({:download, {:error, reason}}, state) do
     Logger.warning(
       "[Distributions] Transient HTTP download error (will retry): #{inspect(reason)}"

--- a/lib/peridiod/plan/step/binary_cache.ex
+++ b/lib/peridiod/plan/step/binary_cache.ex
@@ -68,7 +68,8 @@ defmodule Peridiod.Plan.Step.BinaryCache do
     end
   end
 
-  def handle_info({:source, {:error, reason}}, state) do
+  def handle_info({:source, {:error, {integrity_error, _} = reason}}, state)
+      when integrity_error in [:checksum_mismatch, :size_mismatch] do
     Binary.cache_rm(state.cache_pid, state.binary_metadata)
     {:error, reason, state}
   end

--- a/lib/peridiod/plan/step/binary_cache.ex
+++ b/lib/peridiod/plan/step/binary_cache.ex
@@ -3,6 +3,7 @@ defmodule Peridiod.Plan.Step.BinaryCache do
 
   alias Peridiod.{Binary, Cache, Cloud}
   alias Peridiod.Binary.Downloader
+  alias Peridiod.Binary.Downloader.VerifyConfig
 
   def id(%{binary_metadata: %{prn: prn}}) do
     Module.concat(__MODULE__, prn)
@@ -37,10 +38,16 @@ defmodule Peridiod.Plan.Step.BinaryCache do
     pid = self()
     fun = &send(pid, {:source, &1})
 
+    verify_config = %VerifyConfig{
+      expected_hash: binary_metadata.hash,
+      expected_size: binary_metadata.size
+    }
+
     Downloader.Supervisor.start_child(
       binary_metadata.prn,
       uri,
-      fun
+      fun,
+      verify_config: verify_config
     )
   end
 
@@ -59,6 +66,11 @@ defmodule Peridiod.Plan.Step.BinaryCache do
       error ->
         {:error, error, %{state | step_percent: step_percent}}
     end
+  end
+
+  def handle_info({:source, {:error, reason}}, state) do
+    Binary.cache_rm(state.cache_pid, state.binary_metadata)
+    {:error, reason, state}
   end
 
   def handle_info({:source, :complete}, state) do

--- a/lib/peridiod/plan/step/binary_install.ex
+++ b/lib/peridiod/plan/step/binary_install.ex
@@ -148,7 +148,7 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
 
   def handle_info({:source, {:error, reason}}, state) do
     Binary.cache_rm(state.cache_pid, state.binary_metadata)
-    Installer.stream_finish(state.installer, :invalid_hash, nil)
+    Installer.stream_finish(state.installer, downloader_error_validity(reason), nil)
     {:error, reason, state}
   end
 
@@ -256,4 +256,8 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
         {:error, :cache_file_missing}
     end
   end
+
+  defp downloader_error_validity({:checksum_mismatch, _}), do: :invalid_hash
+  defp downloader_error_validity({:size_mismatch, _}), do: :invalid_hash
+  defp downloader_error_validity(_), do: :invalid_hash
 end

--- a/lib/peridiod/plan/step/binary_install.ex
+++ b/lib/peridiod/plan/step/binary_install.ex
@@ -146,7 +146,8 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
      %{state | hash_accumulator: hash, byte_counter: byte_counter, step_percent: step_percent}}
   end
 
-  def handle_info({:source, {:error, reason}}, state) do
+  def handle_info({:source, {:error, {integrity_error, _} = reason}}, state)
+      when integrity_error in [:checksum_mismatch, :size_mismatch] do
     Binary.cache_rm(state.cache_pid, state.binary_metadata)
     Installer.stream_finish(state.installer, downloader_error_validity(reason), nil)
     {:error, reason, state}

--- a/lib/peridiod/plan/step/binary_install.ex
+++ b/lib/peridiod/plan/step/binary_install.ex
@@ -149,7 +149,7 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
   def handle_info({:source, {:error, {integrity_error, _} = reason}}, state)
       when integrity_error in [:checksum_mismatch, :size_mismatch] do
     Binary.cache_rm(state.cache_pid, state.binary_metadata)
-    Installer.stream_finish(state.installer, downloader_error_validity(reason), nil)
+    Installer.stream_error(state.installer, reason)
     {:error, reason, state}
   end
 
@@ -257,8 +257,4 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
         {:error, :cache_file_missing}
     end
   end
-
-  defp downloader_error_validity({:checksum_mismatch, _}), do: :invalid_hash
-  defp downloader_error_validity({:size_mismatch, _}), do: :invalid_hash
-  defp downloader_error_validity(_), do: :invalid_hash
 end

--- a/lib/peridiod/plan/step/binary_install.ex
+++ b/lib/peridiod/plan/step/binary_install.ex
@@ -5,6 +5,7 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
 
   alias Peridiod.{Binary, Cache, Cloud, Crypto}
   alias Peridiod.Binary.{Downloader, Installer}
+  alias Peridiod.Binary.Downloader.VerifyConfig
 
   def id(%{binary_metadata: %{prn: prn}}) do
     Module.concat(__MODULE__, prn)
@@ -96,10 +97,16 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
     pid = self()
     fun = &send(pid, {:source, &1})
 
+    verify_config = %VerifyConfig{
+      expected_hash: state.binary_metadata.hash,
+      expected_size: state.binary_metadata.size
+    }
+
     Downloader.Supervisor.start_child(
       state.binary_metadata.prn,
       uri,
-      fun
+      fun,
+      verify_config: verify_config
     )
   end
 
@@ -137,6 +144,12 @@ defmodule Peridiod.Plan.Step.BinaryInstall do
 
     {:noreply,
      %{state | hash_accumulator: hash, byte_counter: byte_counter, step_percent: step_percent}}
+  end
+
+  def handle_info({:source, {:error, reason}}, state) do
+    Binary.cache_rm(state.cache_pid, state.binary_metadata)
+    Installer.stream_finish(state.installer, :invalid_hash, nil)
+    {:error, reason, state}
   end
 
   def handle_info({:source, {:eof, :invalid_signature, hash}}, state) do

--- a/test/peridiod/binary/downloader_test.exs
+++ b/test/peridiod/binary/downloader_test.exs
@@ -228,27 +228,31 @@ defmodule Peridiod.Binary.DownloaderTest do
     end
 
     @tag capture_log: true
-    test "resumed download skips hash verification and still completes" do
+    test "partial resumed download skips hash verification but size still applies" do
       test_pid = self()
       handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
 
+      # existing_size > 0 means this is a true partial resume — hash must be skipped
+      # because the downloader only sees bytes from the resume point onward.
+      # Size verification still works since downloaded_length tracks the running total.
+      existing_size = 512
       verify_config = %VerifyConfig{expected_hash: @bin_1m_hash, expected_size: @bin_1m_size}
       url = URI.parse("http://localhost:4001/1M.bin")
 
-      # Start with existing_size = 0 via start_link_with_resume to simulate a resume path
       {:ok, pid} =
         Downloader.start_link_with_resume(
           "test-resume-hash-skip",
           url,
           handler_fun,
           %RetryConfig{},
-          0,
+          existing_size,
           verify_config
         )
 
       ref = Process.monitor(pid)
 
-      # Should complete (hash skipped for resume) but size should still pass
+      # Hash is skipped for partial resumes; size check passes since
+      # downloaded_length (existing + new bytes) will equal expected_size.
       assert_receive {:handler_received, :complete}, 5000
       assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
     end

--- a/test/peridiod/binary/downloader_test.exs
+++ b/test/peridiod/binary/downloader_test.exs
@@ -2,6 +2,13 @@ defmodule Peridiod.Binary.DownloaderTest do
   use PeridiodTest.Case
   alias Peridiod.Binary.Downloader
   alias Peridiod.Binary.Downloader.RetryConfig
+  alias Peridiod.Binary.Downloader.VerifyConfig
+
+  # SHA-256 of test/fixtures/binaries/1M.bin
+  @bin_1m_hash Base.decode16!("a073ad730e540107fbb92ee48baab97c9bc16105333a42b15a53bcc183f6f5c2",
+                 case: :lower
+               )
+  @bin_1m_size 1_048_576
 
   describe "fatal HTTP error handling" do
     @tag capture_log: true
@@ -105,6 +112,145 @@ defmodule Peridiod.Binary.DownloaderTest do
 
       # Should exit normally after completion
       assert_receive {:DOWN, ^ref, :process, ^downloader_pid, :normal}, 2000
+    end
+  end
+
+  describe "integrity verification" do
+    @tag capture_log: true
+    test "completes successfully with correct hash" do
+      test_pid = self()
+      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
+
+      verify_config = %VerifyConfig{expected_hash: @bin_1m_hash}
+      url = URI.parse("http://localhost:4001/1M.bin")
+
+      {:ok, pid} =
+        Downloader.start_link("test-hash-ok", url, handler_fun, %RetryConfig{}, verify_config)
+
+      ref = Process.monitor(pid)
+
+      assert_receive {:handler_received, :complete}, 5000
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
+    end
+
+    @tag capture_log: true
+    test "fails with checksum mismatch on wrong hash" do
+      test_pid = self()
+      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
+
+      wrong_hash = :crypto.hash(:sha256, "wrong")
+      verify_config = %VerifyConfig{expected_hash: wrong_hash}
+      url = URI.parse("http://localhost:4001/1M.bin")
+
+      {:ok, pid} =
+        Downloader.start_link("test-hash-bad", url, handler_fun, %RetryConfig{}, verify_config)
+
+      ref = Process.monitor(pid)
+
+      assert_receive {:handler_received, {:error, {:checksum_mismatch, details}}}, 5000
+      assert details[:expected] == wrong_hash
+      assert details[:actual] == @bin_1m_hash
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
+      refute_received {:handler_received, :complete}
+    end
+
+    @tag capture_log: true
+    test "completes successfully with correct size" do
+      test_pid = self()
+      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
+
+      verify_config = %VerifyConfig{expected_size: @bin_1m_size}
+      url = URI.parse("http://localhost:4001/1M.bin")
+
+      {:ok, pid} =
+        Downloader.start_link("test-size-ok", url, handler_fun, %RetryConfig{}, verify_config)
+
+      ref = Process.monitor(pid)
+
+      assert_receive {:handler_received, :complete}, 5000
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
+    end
+
+    @tag capture_log: true
+    test "fails with size mismatch on wrong expected size" do
+      test_pid = self()
+      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
+
+      verify_config = %VerifyConfig{expected_size: 999}
+      url = URI.parse("http://localhost:4001/1M.bin")
+
+      {:ok, pid} =
+        Downloader.start_link("test-size-bad", url, handler_fun, %RetryConfig{}, verify_config)
+
+      ref = Process.monitor(pid)
+
+      assert_receive {:handler_received, {:error, {:size_mismatch, details}}}, 5000
+      assert details[:expected] == 999
+      assert details[:actual] == @bin_1m_size
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
+      refute_received {:handler_received, :complete}
+    end
+
+    @tag capture_log: true
+    test "completes successfully with both correct hash and size" do
+      test_pid = self()
+      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
+
+      verify_config = %VerifyConfig{expected_hash: @bin_1m_hash, expected_size: @bin_1m_size}
+      url = URI.parse("http://localhost:4001/1M.bin")
+
+      {:ok, pid} =
+        Downloader.start_link(
+          "test-hash-size-ok",
+          url,
+          handler_fun,
+          %RetryConfig{},
+          verify_config
+        )
+
+      ref = Process.monitor(pid)
+
+      assert_receive {:handler_received, :complete}, 5000
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
+    end
+
+    @tag capture_log: true
+    test "backward compatible without verify_config" do
+      test_pid = self()
+      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
+
+      url = URI.parse("http://localhost:4001/1M.bin")
+      {:ok, pid} = Downloader.start_link("test-no-verify", url, handler_fun, %RetryConfig{})
+      ref = Process.monitor(pid)
+
+      assert_receive {:handler_received, :complete}, 5000
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
+    end
+
+    @tag capture_log: true
+    test "resumed download skips hash verification and still completes" do
+      test_pid = self()
+      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
+
+      verify_config = %VerifyConfig{expected_hash: @bin_1m_hash, expected_size: @bin_1m_size}
+      url = URI.parse("http://localhost:4001/1M.bin")
+
+      # Start with existing_size = 0 via start_link_with_resume to simulate a resume path
+      {:ok, pid} =
+        Downloader.start_link_with_resume(
+          "test-resume-hash-skip",
+          url,
+          handler_fun,
+          %RetryConfig{},
+          0,
+          verify_config
+        )
+
+      ref = Process.monitor(pid)
+
+      # Should complete (hash skipped for resume) but size should still pass
+      assert_receive {:handler_received, :complete}, 5000
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
     end
   end
 end

--- a/test/peridiod/binary/downloader_test.exs
+++ b/test/peridiod/binary/downloader_test.exs
@@ -116,16 +116,29 @@ defmodule Peridiod.Binary.DownloaderTest do
   end
 
   describe "integrity verification" do
+    # Only forward terminal events (:complete, {:error, ...}) to the test mailbox,
+    # not {:stream, data} chunks, to avoid flooding the mailbox with binary data.
+    defp verify_handler(test_pid) do
+      fn
+        {:stream, _} -> :ok
+        msg -> send(test_pid, {:handler_received, msg})
+      end
+    end
+
     @tag capture_log: true
     test "completes successfully with correct hash" do
       test_pid = self()
-      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
-
       verify_config = %VerifyConfig{expected_hash: @bin_1m_hash}
       url = URI.parse("http://localhost:4001/1M.bin")
 
       {:ok, pid} =
-        Downloader.start_link("test-hash-ok", url, handler_fun, %RetryConfig{}, verify_config)
+        Downloader.start_link(
+          "test-hash-ok",
+          url,
+          verify_handler(test_pid),
+          %RetryConfig{},
+          verify_config
+        )
 
       ref = Process.monitor(pid)
 
@@ -136,14 +149,18 @@ defmodule Peridiod.Binary.DownloaderTest do
     @tag capture_log: true
     test "fails with checksum mismatch on wrong hash" do
       test_pid = self()
-      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
-
       wrong_hash = :crypto.hash(:sha256, "wrong")
       verify_config = %VerifyConfig{expected_hash: wrong_hash}
       url = URI.parse("http://localhost:4001/1M.bin")
 
       {:ok, pid} =
-        Downloader.start_link("test-hash-bad", url, handler_fun, %RetryConfig{}, verify_config)
+        Downloader.start_link(
+          "test-hash-bad",
+          url,
+          verify_handler(test_pid),
+          %RetryConfig{},
+          verify_config
+        )
 
       ref = Process.monitor(pid)
 
@@ -157,13 +174,17 @@ defmodule Peridiod.Binary.DownloaderTest do
     @tag capture_log: true
     test "completes successfully with correct size" do
       test_pid = self()
-      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
-
       verify_config = %VerifyConfig{expected_size: @bin_1m_size}
       url = URI.parse("http://localhost:4001/1M.bin")
 
       {:ok, pid} =
-        Downloader.start_link("test-size-ok", url, handler_fun, %RetryConfig{}, verify_config)
+        Downloader.start_link(
+          "test-size-ok",
+          url,
+          verify_handler(test_pid),
+          %RetryConfig{},
+          verify_config
+        )
 
       ref = Process.monitor(pid)
 
@@ -174,13 +195,17 @@ defmodule Peridiod.Binary.DownloaderTest do
     @tag capture_log: true
     test "fails with size mismatch on wrong expected size" do
       test_pid = self()
-      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
-
       verify_config = %VerifyConfig{expected_size: 999}
       url = URI.parse("http://localhost:4001/1M.bin")
 
       {:ok, pid} =
-        Downloader.start_link("test-size-bad", url, handler_fun, %RetryConfig{}, verify_config)
+        Downloader.start_link(
+          "test-size-bad",
+          url,
+          verify_handler(test_pid),
+          %RetryConfig{},
+          verify_config
+        )
 
       ref = Process.monitor(pid)
 
@@ -194,8 +219,6 @@ defmodule Peridiod.Binary.DownloaderTest do
     @tag capture_log: true
     test "completes successfully with both correct hash and size" do
       test_pid = self()
-      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
-
       verify_config = %VerifyConfig{expected_hash: @bin_1m_hash, expected_size: @bin_1m_size}
       url = URI.parse("http://localhost:4001/1M.bin")
 
@@ -203,7 +226,7 @@ defmodule Peridiod.Binary.DownloaderTest do
         Downloader.start_link(
           "test-hash-size-ok",
           url,
-          handler_fun,
+          verify_handler(test_pid),
           %RetryConfig{},
           verify_config
         )
@@ -217,10 +240,11 @@ defmodule Peridiod.Binary.DownloaderTest do
     @tag capture_log: true
     test "backward compatible without verify_config" do
       test_pid = self()
-      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
-
       url = URI.parse("http://localhost:4001/1M.bin")
-      {:ok, pid} = Downloader.start_link("test-no-verify", url, handler_fun, %RetryConfig{})
+
+      {:ok, pid} =
+        Downloader.start_link("test-no-verify", url, verify_handler(test_pid), %RetryConfig{})
+
       ref = Process.monitor(pid)
 
       assert_receive {:handler_received, :complete}, 5000
@@ -230,7 +254,6 @@ defmodule Peridiod.Binary.DownloaderTest do
     @tag capture_log: true
     test "partial resumed download skips hash verification but size still applies" do
       test_pid = self()
-      handler_fun = fn msg -> send(test_pid, {:handler_received, msg}) end
 
       # existing_size > 0 means this is a true partial resume — hash must be skipped
       # because the downloader only sees bytes from the resume point onward.
@@ -243,7 +266,7 @@ defmodule Peridiod.Binary.DownloaderTest do
         Downloader.start_link_with_resume(
           "test-resume-hash-skip",
           url,
-          handler_fun,
+          verify_handler(test_pid),
           %RetryConfig{},
           existing_size,
           verify_config

--- a/test/peridiod/plan/step_test.exs
+++ b/test/peridiod/plan/step_test.exs
@@ -43,7 +43,7 @@ defmodule Peridiod.Plan.StepTest do
       {:ok, step_pid} = Step.start_link({step_mod, step_opts})
       Step.execute(step_pid)
 
-      assert_receive {Step, ^step_pid, {:error, :invalid_signature}}
+      assert_receive {Step, ^step_pid, {:error, {:checksum_mismatch, _}}}
     end
   end
 
@@ -102,7 +102,7 @@ defmodule Peridiod.Plan.StepTest do
       {:ok, step_pid} = Step.start_link({step_mod, step_opts})
       Step.execute(step_pid)
 
-      assert_receive {Step, ^step_pid, {:error, :invalid_hash}}
+      assert_receive {Step, ^step_pid, {:error, {:checksum_mismatch, _}}}
       refute Binary.installed?(cache_pid, binary_metadata)
     end
 


### PR DESCRIPTION
## Summary

- Adds a new `Peridiod.Binary.Downloader.VerifyConfig` struct for opt-in SHA-256 hash and size verification at the HTTP transport layer
- The `Downloader` now incrementally hashes streamed bytes via `:crypto.hash_update/2` and verifies against the expected hash/size on completion, emitting `{:error, {:checksum_mismatch, ...}}` or `{:error, {:size_mismatch, ...}}` on failure (process exits normally, no supervisor restart)
- `BinaryInstall` and `BinaryCache` now pass `VerifyConfig` built from `Binary.t()` metadata to the downloader, adding defense-in-depth on top of their existing post-download verification. Integrity error handlers match only `{:checksum_mismatch, _}` and `{:size_mismatch, _}` explicitly — transient downloader errors (idle timeout, TCP reset) are left unhandled so the Downloader's built-in retry semantics are preserved
- Hash verification is skipped for partial resumed downloads (downloader only sees bytes from the resume point onward); size verification and full hash verification for `existing_size == 0` still apply

**Out of scope:** `Distribution.Server` wiring. The legacy `Distribution.t()` payload has no `hash` field, so there is no expected hash to verify against. Integrity checks on the firmware download path require a server-side protocol change to include a hash in the distribution manifest. That work is tracked separately.

## Test plan

- [ ] `mix test test/peridiod/binary/downloader_test.exs` — 12 tests (7 new) covering correct hash, wrong hash, correct size, wrong size, combined, backward compat, and partial resume path
- [ ] `mix test` — all 197 tests pass, no regressions
- [ ] `mix compile --warnings-as-errors` — clean build

Closes ENG-1712