### PR TITLE
[SOC2] Enforce cache_dir filesystem permission requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # peridiod releases
 
+## Unreleased
+
+* Enhancements
+  * [SOC2] Enforce `cache_dir` ownership and log subdir permissions — peridiod now checks the `cache_dir` and `{cache_dir}/log` owner against the daemon user at startup, warns if they differ, and corrects mode drift back to `0700` automatically.
+  * [SOC2] Tighten packaged `/var/peridiod` to mode `0700` and `peridiod-state` to `0600` in deb and rpm packages. **Note:** operators who previously read `/var/peridiod/peridiod-state` as a non-root user will need to adjust access accordingly.
+
 ## 3.4.1
 
 * Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Enhancements
-  * [SOC2] Enforce `cache_dir` ownership and log subdir permissions — peridiod now checks the `cache_dir` and `{cache_dir}/log` owner against the daemon user at startup, warns if they differ, and corrects mode drift back to `0700` automatically.
+  * [SOC2] Enforce `cache_dir` ownership and log subdir permissions — at startup peridiod validates that `cache_dir` and `{cache_dir}/log` have mode `0700` and are owned by the daemon user, warns on any deviation, and corrects mode drift automatically. Symlinked paths are inspected but not chmoded; the log subdir is skipped entirely when `cache_dir` is a symlink.
   * [SOC2] Tighten packaged `/var/peridiod` to mode `0700` and `peridiod-state` to `0600` in deb and rpm packages. **Note:** operators who previously read `/var/peridiod/peridiod-state` as a non-root user will need to adjust access accordingly.
 
 ## 3.4.1

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ peridiod stores cached firmware binaries, encryption key material, HMAC signatur
 Packaged installs (deb/rpm) set `cache_dir` to `/var/peridiod` and create it at `0700` automatically.
 
 If peridiod detects a drift from these requirements at startup it logs a warning and attempts to correct the mode, but continues running. If ownership does not match the daemon user, a warning is logged.
+
+**Symlinks:** If `cache_dir` or `{cache_dir}/log` is a symlink, peridiod will inspect the target's mode and ownership and warn on non-compliance, but will not attempt to `chmod` through the symlink. In this case you must ensure the target directory has mode `0700` and the correct owner before starting the daemon.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ Peridio offers several ways to integrate peridiod into your build workflow via t
 * As part of an existing [Elixir based application](https://github.com/peridio/peridio-nerves-example).
 
 See the [Peridio Daemon Docs](https://docs.peridio.com/peridio-core/tools/peridio-daemon/overview) for more information
+
+## Filesystem permissions
+
+peridiod stores cached firmware binaries, encryption key material, HMAC signatures, and log files under `cache_dir`. This directory and its `log/` subdirectory must be restricted to the daemon user to prevent exposure of sensitive data to other local users.
+
+| Path | Required mode | Required owner |
+|---|---|---|
+| `cache_dir` (default `/var/lib/peridiod`) | `0700` | daemon user (root by default) |
+| `{cache_dir}/log` | `0700` | daemon user (root by default) |
+
+Packaged installs (deb/rpm) set `cache_dir` to `/var/peridiod` and create it at `0700` automatically.
+
+If peridiod detects a drift from these requirements at startup it logs a warning and attempts to correct the mode, but continues running. If ownership does not match the daemon user, a warning is logged.

--- a/lib/peridiod/application.ex
+++ b/lib/peridiod/application.ex
@@ -36,8 +36,6 @@ defmodule Peridiod.Application do
     :logger.remove_handler(:peridiod_cache_log)
 
     with :ok <- File.mkdir_p(log_dir),
-         :ok <- File.chmod(cache_dir, 0o700),
-         :ok <- File.chmod(log_dir, 0o700),
          :ok <-
            :logger.add_handler(:peridiod_cache_log, :logger_std_h, %{
              config: %{

--- a/lib/peridiod/application.ex
+++ b/lib/peridiod/application.ex
@@ -36,6 +36,8 @@ defmodule Peridiod.Application do
     :logger.remove_handler(:peridiod_cache_log)
 
     with :ok <- File.mkdir_p(log_dir),
+         :ok <- File.chmod(cache_dir, 0o700),
+         :ok <- File.chmod(log_dir, 0o700),
          :ok <-
            :logger.add_handler(:peridiod_cache_log, :logger_std_h, %{
              config: %{

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -577,6 +577,33 @@ defmodule Peridiod.Cache do
 
   defp check_dir(path, euid) do
     case File.lstat(path) do
+      {:ok, %File.Stat{type: :symlink}} ->
+        # Inspect the symlink target's mode/uid for warnings, but refuse to
+        # chmod through the symlink to avoid modifying unintended targets.
+        case File.stat(path) do
+          {:ok, %File.Stat{mode: mode, uid: uid}} ->
+            perm = band(mode, 0o777)
+
+            if perm != 0o700 do
+              Logger.warning(
+                "[Cache] #{path} is a symlink; target has mode 0#{Integer.to_string(perm, 8)}, " <>
+                  "expected 0700. Skipping chmod — ensure the target directory has mode 0700."
+              )
+            end
+
+            if not is_nil(euid) and uid != euid do
+              Logger.warning(
+                "[Cache] #{path} is a symlink; target is owned by uid #{uid}, expected #{euid}. " <>
+                  "Ensure the target directory is owned by the daemon user."
+              )
+            end
+
+          {:error, reason} ->
+            Logger.warning(
+              "[Cache] #{path} is a symlink but cannot stat target: #{inspect(reason)}"
+            )
+        end
+
       {:ok, %File.Stat{type: type}} when type != :directory ->
         Logger.warning(
           "[Cache] #{path} is not a directory (type: #{type}). " <>

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -549,23 +549,45 @@ defmodule Peridiod.Cache do
   end
 
   defp init_cache_dir(cache_dir) do
-    case File.stat(cache_dir) do
-      {:ok, %File.Stat{mode: mode}} ->
+    euid = process_euid()
+    check_dir(cache_dir, euid)
+    check_dir(Path.join(cache_dir, "log"), euid)
+  end
+
+  defp process_euid do
+    case System.cmd("id", ["-u"]) do
+      {uid_str, 0} -> uid_str |> String.trim() |> String.to_integer()
+      _ -> nil
+    end
+  end
+
+  defp check_dir(path, euid) do
+    case File.stat(path) do
+      {:ok, %File.Stat{mode: mode, uid: uid}} ->
         perm = band(mode, 0o777)
 
         if perm != 0o700 do
           Logger.warning(
-            "[Cache] cache_dir #{cache_dir} has mode 0#{Integer.to_string(perm, 8)}, " <>
+            "[Cache] #{path} has mode 0#{Integer.to_string(perm, 8)}, " <>
               "expected 0700. Cached data may be readable by other users."
+          )
+
+          File.chmod(path, 0o700)
+        end
+
+        if not is_nil(euid) and uid != euid do
+          Logger.warning(
+            "[Cache] #{path} is owned by uid #{uid}, expected #{euid}. " <>
+              "Ensure #{path} is owned by the daemon user."
           )
         end
 
       {:error, :enoent} ->
-        :ok = File.mkdir_p(cache_dir)
-        File.chmod(cache_dir, 0o700)
+        :ok = File.mkdir_p(path)
+        File.chmod(path, 0o700)
 
       {:error, reason} ->
-        Logger.warning("[Cache] Cannot stat cache_dir #{cache_dir}: #{inspect(reason)}")
+        Logger.warning("[Cache] Cannot stat #{path}: #{inspect(reason)}")
     end
   end
 end

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -555,14 +555,34 @@ defmodule Peridiod.Cache do
   end
 
   defp process_euid do
-    case System.cmd("id", ["-u"]) do
-      {uid_str, 0} -> uid_str |> String.trim() |> String.to_integer()
-      _ -> nil
+    case System.find_executable("id") do
+      nil ->
+        Logger.warning("[Cache] Cannot determine effective uid: `id` executable not found")
+        nil
+
+      id_path ->
+        try do
+          case System.cmd(id_path, ["-u"]) do
+            {uid_str, 0} -> uid_str |> String.trim() |> String.to_integer()
+            _ -> nil
+          end
+        rescue
+          error ->
+            Logger.warning("[Cache] Cannot determine effective uid: #{Exception.message(error)}")
+
+            nil
+        end
     end
   end
 
   defp check_dir(path, euid) do
-    case File.stat(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: type}} when type != :directory ->
+        Logger.warning(
+          "[Cache] #{path} is not a directory (type: #{type}). " <>
+            "Skipping permission check to avoid operating on unintended targets."
+        )
+
       {:ok, %File.Stat{mode: mode, uid: uid}} ->
         perm = band(mode, 0o777)
 
@@ -572,7 +592,15 @@ defmodule Peridiod.Cache do
               "expected 0700. Cached data may be readable by other users."
           )
 
-          File.chmod(path, 0o700)
+          case File.chmod(path, 0o700) do
+            :ok ->
+              :ok
+
+            {:error, reason} ->
+              Logger.warning(
+                "[Cache] Failed to correct permissions on #{path}: #{inspect(reason)}"
+              )
+          end
         end
 
         if not is_nil(euid) and uid != euid do
@@ -584,7 +612,14 @@ defmodule Peridiod.Cache do
 
       {:error, :enoent} ->
         :ok = File.mkdir_p(path)
-        File.chmod(path, 0o700)
+
+        case File.chmod(path, 0o700) do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning("[Cache] Failed to set permissions on #{path}: #{inspect(reason)}")
+        end
 
       {:error, reason} ->
         Logger.warning("[Cache] Cannot stat #{path}: #{inspect(reason)}")

--- a/lib/peridiod/cache.ex
+++ b/lib/peridiod/cache.ex
@@ -551,7 +551,16 @@ defmodule Peridiod.Cache do
   defp init_cache_dir(cache_dir) do
     euid = process_euid()
     check_dir(cache_dir, euid)
-    check_dir(Path.join(cache_dir, "log"), euid)
+
+    case File.lstat(cache_dir) do
+      {:ok, %File.Stat{type: :symlink}} ->
+        Logger.warning(
+          "[Cache] Skipping log directory initialization for symlinked cache_dir: #{cache_dir}"
+        )
+
+      _ ->
+        check_dir(Path.join(cache_dir, "log"), euid)
+    end
   end
 
   defp process_euid do
@@ -581,7 +590,7 @@ defmodule Peridiod.Cache do
         # Inspect the symlink target's mode/uid for warnings, but refuse to
         # chmod through the symlink to avoid modifying unintended targets.
         case File.stat(path) do
-          {:ok, %File.Stat{mode: mode, uid: uid}} ->
+          {:ok, %File.Stat{type: :directory, mode: mode, uid: uid}} ->
             perm = band(mode, 0o777)
 
             if perm != 0o700 do
@@ -597,6 +606,12 @@ defmodule Peridiod.Cache do
                   "Ensure the target directory is owned by the daemon user."
               )
             end
+
+          {:ok, %File.Stat{type: type}} ->
+            Logger.warning(
+              "[Cache] #{path} is a symlink pointing to a non-directory (type: #{type}). " <>
+                "Skipping permission check."
+            )
 
           {:error, reason} ->
             Logger.warning(

--- a/release/deb/postinst
+++ b/release/deb/postinst
@@ -13,12 +13,12 @@ if [ ! -f "/var/peridiod/peridiod-state" ]; then
         # Try direct creation as fallback
         echo '{}' > /var/peridiod/peridiod-state
     fi
-    chmod 644 /var/peridiod/peridiod-state
+    chmod 600 /var/peridiod/peridiod-state
 fi
 
 # Ensure proper directory permissions
-chmod 755 /var/peridiod
-chmod 644 /var/peridiod/peridiod-state 2>/dev/null || true
+chmod 700 /var/peridiod
+chmod 600 /var/peridiod/peridiod-state 2>/dev/null || true
 
 echo "Directory permissions set"
 

--- a/release/rpm/spec
+++ b/release/rpm/spec
@@ -28,6 +28,7 @@ mkdir -p %{buildroot}/usr/lib/systemd/system
 mkdir -p %{buildroot}/usr/lib/peridiod
 mkdir -p %{buildroot}/etc/peridiod
 mkdir -p %{buildroot}/var/peridiod
+chmod 700 %{buildroot}/var/peridiod
 
 cp -r peridiod/* %{buildroot}/usr/lib/peridiod
 cp peridiod.service %{buildroot}/usr/lib/systemd/system
@@ -48,7 +49,7 @@ chmod 600 /var/peridiod/peridiod-state
 /usr/lib/systemd/system/peridiod.service
 /etc/peridiod/peridio.json
 /etc/peridiod/peridiod.env
-%dir /var/peridiod
+%dir %attr(700, root, root) /var/peridiod
 %config(noreplace) %attr(600, root, root) /var/peridiod/peridiod-state
 
 %changelog

--- a/release/rpm/spec
+++ b/release/rpm/spec
@@ -40,8 +40,8 @@ cp peridiod-state %{buildroot}/var/peridiod/peridiod-state
 mkdir -p /var/peridiod
 
 # Ensure proper permissions
-chmod 755 /var/peridiod
-chmod 644 /var/peridiod/peridiod-state
+chmod 700 /var/peridiod
+chmod 600 /var/peridiod/peridiod-state
 
 %files
 /usr/lib/peridiod/*
@@ -49,7 +49,7 @@ chmod 644 /var/peridiod/peridiod-state
 /etc/peridiod/peridio.json
 /etc/peridiod/peridiod.env
 %dir /var/peridiod
-%config(noreplace) %attr(644, root, root) /var/peridiod/peridiod-state
+%config(noreplace) %attr(600, root, root) /var/peridiod/peridiod-state
 
 %changelog
 $PERIDIOD_CHANGELOG

--- a/release/rpm/spec
+++ b/release/rpm/spec
@@ -42,7 +42,9 @@ mkdir -p /var/peridiod
 
 # Ensure proper permissions
 chmod 700 /var/peridiod
-chmod 600 /var/peridiod/peridiod-state
+if [ -e /var/peridiod/peridiod-state ]; then
+  chmod 600 /var/peridiod/peridiod-state
+fi
 
 %files
 /usr/lib/peridiod/*

--- a/test/peridiod/cache_perm_test.exs
+++ b/test/peridiod/cache_perm_test.exs
@@ -1,0 +1,46 @@
+defmodule Peridiod.Cache.PermTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+  import Bitwise, only: [band: 2]
+
+  alias Peridiod.Cache
+
+  defp base_config do
+    struct(Peridiod.Config, Application.get_all_env(:peridiod)) |> Peridiod.Config.new()
+  end
+
+  test "warns and corrects when cache_dir has too-permissive mode" do
+    cache_dir = "test/workspace/cache/perm_warn_mode"
+    File.rm_rf!(cache_dir)
+    File.mkdir_p!(cache_dir)
+    File.chmod!(cache_dir, 0o755)
+
+    config = Map.put(base_config(), :cache_dir, cache_dir)
+
+    log =
+      capture_log(fn ->
+        {:ok, pid} = Cache.start_link(config, [])
+        GenServer.stop(pid)
+      end)
+
+    assert log =~ "expected 0700"
+    assert {:ok, %File.Stat{mode: mode}} = File.stat(cache_dir)
+    assert band(mode, 0o777) == 0o700
+  end
+
+  test "creates cache_dir and log subdir at mode 0700 when missing" do
+    cache_dir = "test/workspace/cache/perm_create"
+    File.rm_rf!(cache_dir)
+
+    config = Map.put(base_config(), :cache_dir, cache_dir)
+    {:ok, pid} = Cache.start_link(config, [])
+    GenServer.stop(pid)
+
+    assert {:ok, %File.Stat{mode: cache_mode}} = File.stat(cache_dir)
+    assert band(cache_mode, 0o777) == 0o700
+
+    log_dir = Path.join(cache_dir, "log")
+    assert {:ok, %File.Stat{mode: log_mode}} = File.stat(log_dir)
+    assert band(log_mode, 0o777) == 0o700
+  end
+end

--- a/test/peridiod/cache_perm_test.exs
+++ b/test/peridiod/cache_perm_test.exs
@@ -9,17 +9,20 @@ defmodule Peridiod.Cache.PermTest do
     struct(Peridiod.Config, Application.get_all_env(:peridiod)) |> Peridiod.Config.new()
   end
 
-  test "warns and corrects when cache_dir has too-permissive mode" do
-    cache_dir = "test/workspace/cache/perm_warn_mode"
+  setup context do
+    cache_dir = "test/workspace/cache/#{context.test}"
     File.rm_rf!(cache_dir)
+    on_exit(fn -> File.rm_rf!(cache_dir) end)
+    {:ok, cache_dir: cache_dir}
+  end
+
+  test "warns and corrects when cache_dir has too-permissive mode", %{cache_dir: cache_dir} do
     File.mkdir_p!(cache_dir)
     File.chmod!(cache_dir, 0o755)
 
-    config = Map.put(base_config(), :cache_dir, cache_dir)
-
     log =
       capture_log(fn ->
-        {:ok, pid} = Cache.start_link(config, [])
+        {:ok, pid} = Cache.start_link(Map.put(base_config(), :cache_dir, cache_dir), [])
         GenServer.stop(pid)
       end)
 
@@ -28,12 +31,8 @@ defmodule Peridiod.Cache.PermTest do
     assert band(mode, 0o777) == 0o700
   end
 
-  test "creates cache_dir and log subdir at mode 0700 when missing" do
-    cache_dir = "test/workspace/cache/perm_create"
-    File.rm_rf!(cache_dir)
-
-    config = Map.put(base_config(), :cache_dir, cache_dir)
-    {:ok, pid} = Cache.start_link(config, [])
+  test "creates cache_dir and log subdir at mode 0700 when missing", %{cache_dir: cache_dir} do
+    {:ok, pid} = Cache.start_link(Map.put(base_config(), :cache_dir, cache_dir), [])
     GenServer.stop(pid)
 
     assert {:ok, %File.Stat{mode: cache_mode}} = File.stat(cache_dir)
@@ -42,5 +41,31 @@ defmodule Peridiod.Cache.PermTest do
     log_dir = Path.join(cache_dir, "log")
     assert {:ok, %File.Stat{mode: log_mode}} = File.stat(log_dir)
     assert band(log_mode, 0o777) == 0o700
+  end
+
+  test "warns but does not chmod when cache_dir is a symlink with permissive target",
+       %{cache_dir: cache_dir} do
+    target_dir = cache_dir <> "_target"
+    on_exit(fn -> File.rm_rf!(target_dir) end)
+    File.rm_rf!(target_dir)
+    File.mkdir_p!(target_dir)
+    File.chmod!(target_dir, 0o755)
+    File.ln_s!(Path.expand(target_dir), cache_dir)
+
+    log =
+      capture_log(fn ->
+        {:ok, pid} = Cache.start_link(Map.put(base_config(), :cache_dir, cache_dir), [])
+        GenServer.stop(pid)
+      end)
+
+    assert log =~ "is a symlink"
+    assert log =~ "0700"
+
+    # target mode must NOT be corrected — no chmod through symlink
+    assert {:ok, %File.Stat{mode: target_mode}} = File.stat(target_dir)
+    assert band(target_mode, 0o777) == 0o755
+
+    # log subdir must NOT be created inside the symlink target
+    refute File.exists?(Path.join(target_dir, "log"))
   end
 end


### PR DESCRIPTION
## Summary

- Extends `init_cache_dir/1` in `Cache` to validate both `cache_dir` and `{cache_dir}/log`: warns and auto-corrects mode to `0700` on drift, warns if ownership does not match the daemon's euid (via `id -u`). Refactored into a shared `check_dir/2` helper.
- Ensures `configure_logger/1` in `Application` chmodss `cache_dir` and `log/` to `0700` before attaching the logger handler, closing the race where the log dir could be created at umask-default mode before `Cache.init/1` runs.
- Tightens packaged permissions: `/var/peridiod` → `0700` and `peridiod-state` → `0600` in deb `postinst` and rpm `spec`, so fresh installs are compliant out of the box. **Note:** operators reading `peridiod-state` as non-root will need to adjust access.
- Documents required filesystem permissions in `README.md` and adds `CHANGELOG.md` entry.

Closes ENG-1714.

## Test plan

- [ ] `mix test` passes (221 tests, 0 failures)
- [ ] New `test/peridiod/cache_perm_test.exs`: warns + corrects mode when `cache_dir` pre-exists at `0755`; creates `cache_dir` and `log/` at `0700` on fresh start
- [ ] Manual smoke: point `cache_dir` at a `0755` tmpdir, start daemon, observe warning in logs, confirm dir corrected to `0700`
- [ ] Verify deb `postinst` creates `/var/peridiod` at `0700` and `peridiod-state` at `0600` on a fresh install