### PR TITLE
[SOC2] Add TLS 1.3 support alongside TLS 1.2

### DIFF
--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -414,7 +414,6 @@ defmodule Peridiod.Config do
     ssl =
       base.ssl
       |> Keyword.put_new(:verify, :verify_peer)
-      |> Keyword.put_new(:versions, [:"tlsv1.2"])
       |> Keyword.put_new(:server_name_indication, to_charlist(base.device_api_sni))
 
     %{base | socket: socket, ssl: ssl}

--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -255,7 +255,8 @@ defmodule Peridiod.Config do
       |> Map.put(:ssl,
         server_name_indication: to_charlist(config.device_api_host),
         verify: verify,
-        cacertfile: config.device_api_ca_certificate_path
+        cacertfile: config.device_api_ca_certificate_path,
+        versions: [:"tlsv1.2", :"tlsv1.3"]
       )
 
     case config.key_pair_source do

--- a/lib/peridiod/config.ex
+++ b/lib/peridiod/config.ex
@@ -256,7 +256,7 @@ defmodule Peridiod.Config do
         server_name_indication: to_charlist(config.device_api_host),
         verify: verify,
         cacertfile: config.device_api_ca_certificate_path,
-        versions: [:"tlsv1.2", :"tlsv1.3"]
+        versions: [:"tlsv1.3", :"tlsv1.2"]
       )
 
     case config.key_pair_source do

--- a/test/peridiod/config_test.exs
+++ b/test/peridiod/config_test.exs
@@ -25,6 +25,15 @@ defmodule Peridiod.ConfigTest do
     end
   end
 
+  describe "tls versions" do
+    test "ssl options include both TLS 1.2 and TLS 1.3" do
+      with_config_file("test/fixtures/peridio.json", fn ->
+        config = build_config()
+        assert config.ssl[:versions] == [:"tlsv1.2", :"tlsv1.3"]
+      end)
+    end
+  end
+
   describe "device_api_verify" do
     test "struct default is :verify_peer" do
       assert %Peridiod.Config{}.device_api_verify == :verify_peer

--- a/test/peridiod/config_test.exs
+++ b/test/peridiod/config_test.exs
@@ -29,7 +29,8 @@ defmodule Peridiod.ConfigTest do
     test "ssl options include both TLS 1.2 and TLS 1.3" do
       with_config_file("test/fixtures/peridio.json", fn ->
         config = build_config()
-        assert config.ssl[:versions] == [:"tlsv1.2", :"tlsv1.3"]
+        assert :"tlsv1.2" in config.ssl[:versions]
+        assert :"tlsv1.3" in config.ssl[:versions]
       end)
     end
   end


### PR DESCRIPTION
## Summary

- Adds `:"tlsv1.3"` to the `:versions` list in `build_config/2` so all TLS connections (Tesla HTTP client and Slipstream WebSocket) can negotiate TLS 1.3 on OTP 27, while retaining TLS 1.2 for backward compatibility with older gateways
- The fix targets `build_config/2` (the actual SSL construction site in `new/1`) — not `base_config/1`, which is overwritten before TLS options take effect
- OTP 27 is used across all build environments, so TLS 1.3 is fully supported; no cipher suite changes are needed as OTP defaults handle TLS 1.3 suites automatically

## Test plan

- [x] `mix test test/peridiod/config_test.exs` — new assertion confirms both `:"tlsv1.2"` and `:"tlsv1.3"` present in `config.ssl[:versions]`
- [x] `mix test` — full suite passes (252 tests, 0 failures)
- [ ] (post-merge smoke) Verify negotiated protocol is `:"tlsv1.3"` against staging cloud via `:ssl.connection_information/1`

Closes ENG-1713.