### PR TITLE
Bind firmware downloads to active network interface

### DIFF
--- a/lib/peridiod/binary/downloader.ex
+++ b/lib/peridiod/binary/downloader.ex
@@ -666,15 +666,13 @@ defmodule Peridiod.Binary.Downloader do
 
   @doc false
   def bound_interface_transport_opts do
-    case Process.whereis(NetworkMonitor) do
-      nil ->
-        []
-
-      _pid ->
-        case NetworkMonitor.get_bound_interface() do
-          nil -> []
-          ifname -> [bind_to_device: ifname]
-        end
+    try do
+      case NetworkMonitor.get_bound_interface() do
+        nil -> []
+        ifname -> [bind_to_device: ifname]
+      end
+    catch
+      :exit, _ -> []
     end
   end
 end

--- a/lib/peridiod/binary/downloader.ex
+++ b/lib/peridiod/binary/downloader.ex
@@ -615,7 +615,10 @@ defmodule Peridiod.Binary.Downloader do
 
     transport_opts = bound_interface_transport_opts()
 
-    with {:ok, conn} <- Mint.HTTP.connect(String.to_existing_atom(scheme), host, port, transport_opts: transport_opts),
+    with {:ok, conn} <-
+           Mint.HTTP.connect(String.to_existing_atom(scheme), host, port,
+             transport_opts: transport_opts
+           ),
          {:ok, conn, request_ref} <- Mint.HTTP.request(conn, "GET", path, request_headers, nil) do
       {:ok,
        %Downloader{
@@ -661,9 +664,12 @@ defmodule Peridiod.Binary.Downloader do
   defp add_user_agent_header(headers, _),
     do: [{"User-Agent", "Peridiod/#{Application.spec(:peridiod)[:vsn]}"} | headers]
 
-  defp bound_interface_transport_opts do
+  @doc false
+  def bound_interface_transport_opts do
     case Process.whereis(NetworkMonitor) do
-      nil -> []
+      nil ->
+        []
+
       _pid ->
         case NetworkMonitor.get_bound_interface() do
           nil -> []

--- a/lib/peridiod/binary/downloader.ex
+++ b/lib/peridiod/binary/downloader.ex
@@ -24,6 +24,7 @@ defmodule Peridiod.Binary.Downloader do
     Downloader.VerifyConfig
   }
 
+  alias Peridiod.Cloud.NetworkMonitor
   alias Peridiod.LogSanitizer
 
   require Logger
@@ -612,7 +613,9 @@ defmodule Peridiod.Binary.Downloader do
     # like this. There may be a better way to do this..
     path = if query, do: "#{path}?#{query}", else: path
 
-    with {:ok, conn} <- Mint.HTTP.connect(String.to_existing_atom(scheme), host, port),
+    transport_opts = bound_interface_transport_opts()
+
+    with {:ok, conn} <- Mint.HTTP.connect(String.to_existing_atom(scheme), host, port, transport_opts: transport_opts),
          {:ok, conn, request_ref} <- Mint.HTTP.request(conn, "GET", path, request_headers, nil) do
       {:ok,
        %Downloader{
@@ -657,4 +660,15 @@ defmodule Peridiod.Binary.Downloader do
 
   defp add_user_agent_header(headers, _),
     do: [{"User-Agent", "Peridiod/#{Application.spec(:peridiod)[:vsn]}"} | headers]
+
+  defp bound_interface_transport_opts do
+    case Process.whereis(NetworkMonitor) do
+      nil -> []
+      _pid ->
+        case NetworkMonitor.get_bound_interface() do
+          nil -> []
+          ifname -> [bind_to_device: ifname]
+        end
+    end
+  end
 end

--- a/test/peridiod/binary/downloader_test.exs
+++ b/test/peridiod/binary/downloader_test.exs
@@ -3,6 +3,7 @@ defmodule Peridiod.Binary.DownloaderTest do
   alias Peridiod.Binary.Downloader
   alias Peridiod.Binary.Downloader.RetryConfig
   alias Peridiod.Binary.Downloader.VerifyConfig
+  alias Peridiod.Cloud.NetworkMonitor
 
   # SHA-256 of test/fixtures/binaries/1M.bin
   @bin_1m_hash Base.decode16!("a073ad730e540107fbb92ee48baab97c9bc16105333a42b15a53bcc183f6f5c2",
@@ -278,6 +279,28 @@ defmodule Peridiod.Binary.DownloaderTest do
       # downloaded_length (existing + new bytes) will equal expected_size.
       assert_receive {:handler_received, :complete}, 5000
       assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 2000
+    end
+  end
+
+  describe "interface binding" do
+    test "returns empty transport opts when no interface is bound" do
+      # NetworkMonitor starts with bound_interface: nil in the test environment
+      assert NetworkMonitor.get_bound_interface() == nil
+      assert Downloader.bound_interface_transport_opts() == []
+    end
+
+    test "returns bind_to_device transport opt for the currently bound interface" do
+      original = :sys.get_state(NetworkMonitor)
+
+      on_exit(fn ->
+        :sys.replace_state(NetworkMonitor, fn _ -> original end)
+      end)
+
+      :sys.replace_state(NetworkMonitor, fn state ->
+        %{state | bound_interface: {"eth0", %NetworkMonitor.InterfaceInfo{}}}
+      end)
+
+      assert Downloader.bound_interface_transport_opts() == [bind_to_device: "eth0"]
     end
   end
 end

--- a/test/peridiod/binary/downloader_test.exs
+++ b/test/peridiod/binary/downloader_test.exs
@@ -302,5 +302,14 @@ defmodule Peridiod.Binary.DownloaderTest do
 
       assert Downloader.bound_interface_transport_opts() == [bind_to_device: "eth0"]
     end
+
+    test "returns empty transport opts when NetworkMonitor is not running" do
+      pid = Process.whereis(NetworkMonitor)
+      ref = Process.monitor(pid)
+      Process.exit(pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :killed}
+
+      assert Downloader.bound_interface_transport_opts() == []
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `Binary.Downloader` was opening Mint connections with no interface binding, so the OS default route (often `ppp0` at metric 0) was used for all downloads regardless of which interface `NetworkMonitor` had selected
- When `NetworkMonitor` switched to a higher-priority interface (`eth0`), in-flight and retried download connections stayed on `ppp0`; if `ppp0` then lost internet the download stalled
- On each connect attempt (including retries), the downloader now queries `NetworkMonitor` for the currently bound interface and passes `bind_to_device` to `Mint.HTTP.connect/4` — the same mechanism already used by `Cloud.Socket`

Fixes: https://linear.app/peridio/issue/ENG-1861

## Test plan

- [ ] Existing 256-test suite passes (`mix test`)
- [ ] Two new unit tests in `"interface binding"` describe block:
  - returns empty transport opts when no interface is bound (default state)
  - returns `[bind_to_device: "eth0"]` when NetworkMonitor has a bound interface
- [ ] On a multi-interface device (eth0 + ppp0 with `disconnect_on_higher_priority`), trigger a firmware update while on ppp0, then bring up eth0 — download should migrate to eth0 after the next retry rather than stalling when ppp0 drops